### PR TITLE
Use Composer to install WP-CLI in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ cache:
 
 env:
   global:
-    - WP_CLI_BIN_DIR=/tmp/wp-cli-phar
+    - PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+    - WP_CLI_BIN_DIR="$TRAVIS_BUILD_DIR/vendor/bin"
 
 matrix:
   include:
@@ -32,9 +33,15 @@ matrix:
     - php: 5.3
       env: WP_VERSION=latest
 
-before_script:
+before_install:
   - phpenv config-rm xdebug.ini
-  - composer validate
+
+install:
+  - composer install
   - bash bin/install-package-tests.sh
 
-script: ./vendor/bin/behat --format progress --strict
+before_script:
+  - composer validate
+
+script:
+  - behat --format progress --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,4 @@ before_script:
   - composer validate
 
 script:
-  - BEHAT_TAGS=$(WP_VERSION=99.99.99 php utils/behat-tags.php) && echo $BEHAT_TAGS
-  - behat --format progress --strict $BEHAT_TAGS
+  - ./bin/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
 
 before_install:
   - phpenv config-rm xdebug.ini
+  - if [[ $TRAVIS_PHP_VERSION = '5.6' || $TRAVIS_PHP_VERSION = '7.0' ]]; then printf "\n" | pecl install imagick; fi
+  - php -m
 
 install:
   - composer install
@@ -44,4 +46,5 @@ before_script:
   - composer validate
 
 script:
-  - behat --format progress --strict
+  - BEHAT_TAGS=$(WP_VERSION=99.99.99 php utils/behat-tags.php) && echo $BEHAT_TAGS
+  - behat --format progress --strict $BEHAT_TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
   - php -m
 
 install:
+  - composer require wp-cli/wp-cli:dev-master
   - composer install
   - bash bin/install-package-tests.sh
 

--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -2,39 +2,9 @@
 
 set -ex
 
-WP_CLI_BIN_DIR=${WP_CLI_BIN_DIR-/tmp/wp-cli-phar}
-
-PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
-
-download() {
-    if [ `which curl` ]; then
-        curl -s "$1" > "$2";
-    elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
-    fi
-}
-
-install_wp_cli() {
-
-	# the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
-	mkdir -p $WP_CLI_BIN_DIR
-	download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
-	chmod +x $WP_CLI_BIN_DIR/wp
-
-}
-
-download_behat() {
-
-	cd $PACKAGE_DIR
-	composer require --dev behat/behat='~2.5'
-
-}
-
 install_db() {
 	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
-install_wp_cli
-download_behat
 install_db

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+# Run the functional tests
+BEHAT_TAGS=$(php utils/behat-tags.php)
+behat --format progress $BEHAT_TAGS --strict

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {"": "src/"},
         "files": [ "media-command.php" ]
@@ -27,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.x-dev"
         },
         "commands": [
             "media import",

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,16 @@
         "psr-4": {"": "src/"},
         "files": [ "media-command.php" ]
     },
-    "require": {},
+    "require": {
+        "wp-cli/wp-cli": "dev-master"
+    },
     "require-dev": {
         "behat/behat": "~2.5"
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        },
         "commands": [
             "media import",
             "media regenerate"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "files": [ "media-command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "dev-master"
+        "wp-cli/wp-cli": "*"
     },
     "require-dev": {
         "behat/behat": "~2.5"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -318,7 +318,8 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 	public function create_config( $subdir = '' ) {
 		$params = self::$db_settings;
-		$params['dbprefix'] = $subdir ?: 'wp_';
+		// Replaces all characters that are not alphanumeric or an underscore into an underscore.
+		$params['dbprefix'] = $subdir ? preg_replace( '#[^a-zA-Z\_0-9]#', '_', $subdir ) : 'wp_';
 
 		$params['skip-salts'] = true;
 		$this->proc( 'wp core config', $params, $subdir )->run_check();

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -74,7 +74,7 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/large-image-125x125.jpg file should exist
     And the wp-content/uploads/large-image-200x200.jpg file should exist
 
-  @require-wp-4.7.1
+  @require-wp-4.7.3 @require-extension-imagick
   Scenario: Delete existing thumbnails when media including PDF is regenerated
     Given download:
       | path                              | url                                                   |
@@ -122,7 +122,7 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/minimal-us-letter-pdf-125x125.jpg file should not exist
     And the wp-content/uploads/minimal-us-letter-pdf-200x200.jpg file should exist
 
-  @require-wp-4.7.1
+  @require-wp-4.7.3 @require-extension-imagick
   Scenario: Skip deletion of existing thumbnails when media including PDF is regenerated
     Given download:
       | path                              | url                                                   |

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -99,7 +99,7 @@ Feature: Regenerate WordPress attachments
 
     When I run `wp media import {CACHE_DIR}/minimal-us-letter.pdf --title="My imported PDF attachment" --porcelain`
     Then save STDOUT as {ATTACHMENT_ID2}
-    And the wp-content/uploads/minimal-us-letter-125x125.jpg file should exist
+    And the wp-content/uploads/minimal-us-letter-pdf-125x125.jpg file should exist
 
     Given a wp-content/mu-plugins/media-settings.php file:
       """
@@ -119,8 +119,8 @@ Feature: Regenerate WordPress attachments
       """
     And the wp-content/uploads/large-image-125x125.jpg file should not exist
     And the wp-content/uploads/large-image-200x200.jpg file should exist
-    And the wp-content/uploads/minimal-us-letter-125x125.jpg file should not exist
-    And the wp-content/uploads/minimal-us-letter-200x200.jpg file should exist
+    And the wp-content/uploads/minimal-us-letter-pdf-125x125.jpg file should not exist
+    And the wp-content/uploads/minimal-us-letter-pdf-200x200.jpg file should exist
 
   @require-wp-4.7.1
   Scenario: Skip deletion of existing thumbnails when media including PDF is regenerated
@@ -147,7 +147,7 @@ Feature: Regenerate WordPress attachments
 
     When I run `wp media import {CACHE_DIR}/minimal-us-letter.pdf --title="My imported PDF attachment" --porcelain`
     Then save STDOUT as {ATTACHMENT_ID2}
-    And the wp-content/uploads/minimal-us-letter-125x125.jpg file should exist
+    And the wp-content/uploads/minimal-us-letter-pdf-125x125.jpg file should exist
 
     Given a wp-content/mu-plugins/media-settings.php file:
       """
@@ -167,8 +167,8 @@ Feature: Regenerate WordPress attachments
       """
     And the wp-content/uploads/large-image-125x125.jpg file should exist
     And the wp-content/uploads/large-image-200x200.jpg file should exist
-    And the wp-content/uploads/minimal-us-letter-125x125.jpg file should exist
-    And the wp-content/uploads/minimal-us-letter-200x200.jpg file should exist
+    And the wp-content/uploads/minimal-us-letter-pdf-125x125.jpg file should exist
+    And the wp-content/uploads/minimal-us-letter-pdf-1-200x200.jpg file should exist
 
   Scenario: Provide helpful error messages when media can't be regenerated
     Given download:

--- a/media-command.php
+++ b/media-command.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 $autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
+if ( file_exists( $autoload ) && ! class_exists( 'Media_Command' ) ) {
 	require_once $autoload;
 }
 

--- a/media-command.php
+++ b/media-command.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 $autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) && ! class_exists( 'Media_Command' ) ) {
+if ( file_exists( $autoload ) ) {
 	require_once $autoload;
 }
 

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -40,6 +40,26 @@ $skip_tags = array_merge(
 # Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
 $skip_tags[] = '@github-api';
 
+# Require PHP extension, eg 'imagick'.
+function extension_tags() {
+	$extension_tags = array();
+	exec( "grep '@require-extension-[A-Za-z_]*' -h -o features/*.feature | uniq", $extension_tags );
+
+	$skip_tags = array();
+
+	$substr_start = strlen( '@require-extension-' );
+	foreach ( $extension_tags as $tag ) {
+		$extension = substr( $tag, $substr_start );
+		if ( ! extension_loaded( $extension ) ) {
+			$skip_tags[] = $tag;
+		}
+	}
+
+	return $skip_tags;
+}
+
+$skip_tags = array_merge( $skip_tags, extension_tags() );
+
 if ( !empty( $skip_tags ) ) {
 	echo '--tags=~' . implode( '&&~', $skip_tags );
 }


### PR DESCRIPTION
Doing so ensures tests run against local copy of command, instead of
Phar bundled version.

See https://github.com/wp-cli/wp-cli/issues/3850#issuecomment-288719442