### PR TITLE
Install Imagick for all versions of PHP.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
   directories:
     - vendor
     - $HOME/.composer/cache
+    - $HOME/opt/$TRAVIS_PHP_VERSION
 env:
   global:
     - PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
@@ -35,7 +36,7 @@ matrix:
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then printf "\n" | pecl install imagick; fi
+  - bash bin/install-imagick.sh
   - php -m
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   directories:
     - vendor
     - $HOME/.composer/cache
-    - $HOME/opt/$TRAVIS_PHP_VERSION
+    - $HOME/opt/$WP_VERSION/$TRAVIS_PHP_VERSION
 env:
   global:
     - PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"

--- a/bin/install-imagick.sh
+++ b/bin/install-imagick.sh
@@ -7,6 +7,7 @@ IMAGEMAGICK_VERSION='6.9.7-10'
 IMAGICK_VERSION='3.4.3'
 
 if [[ "$TRAVIS_PHP_VERSION" = '7.1' ]]; then
+	# This non-10 version will probably disappear in the near future.
 	IMAGEMAGICK_VERSION='6.9.8-8'
 fi
 

--- a/bin/install-imagick.sh
+++ b/bin/install-imagick.sh
@@ -13,18 +13,18 @@ install_imagemagick() {
 	rm "ImageMagick-$IMAGEMAGICK_VERSION.tar.xz"
 	cd "ImageMagick-$IMAGEMAGICK_VERSION"
 
-	./configure --prefix="$HOME/opt/$TRAVIS_PHP_VERSION" --with-perl=no
+	./configure --prefix="$HOME/opt/$WP_VERSION/$TRAVIS_PHP_VERSION" --with-perl=no
 	make
 	make install
 
 	# Don't need doc - saves around 24M.
-	if [[ -d "$HOME/opt/$TRAVIS_PHP_VERSION/share/doc" ]]; then rm -rf "$HOME/opt/$TRAVIS_PHP_VERSION/share/doc"; fi
+	if [[ -d "$HOME/opt/$WP_VERSION/$TRAVIS_PHP_VERSION/share/doc" ]]; then rm -rf "$HOME/opt/$WP_VERSION/$TRAVIS_PHP_VERSION/share/doc"; fi
 
 	cd "$TRAVIS_BUILD_DIR"
 }
 
 # Install ImageMagick if the current version isn't up to date
-PATH="$HOME/opt/$TRAVIS_PHP_VERSION/bin:$PATH" identify -version | grep "$IMAGEMAGICK_VERSION" || install_imagemagick
+PATH="$HOME/opt/$WP_VERSION/$TRAVIS_PHP_VERSION/bin:$PATH" identify -version | grep "$IMAGEMAGICK_VERSION" || install_imagemagick
 
 # Install Imagick for PHP
-echo "$HOME/opt/$TRAVIS_PHP_VERSION" | pecl install -f "imagick-$IMAGICK_VERSION"
+echo "$HOME/opt/$WP_VERSION/$TRAVIS_PHP_VERSION" | pecl install -f "imagick-$IMAGICK_VERSION"

--- a/bin/install-imagick.sh
+++ b/bin/install-imagick.sh
@@ -7,8 +7,7 @@ IMAGEMAGICK_VERSION='6.9.7-10'
 IMAGICK_VERSION='3.4.3'
 
 if [[ "$TRAVIS_PHP_VERSION" = '7.1' ]]; then
-	# This non-10 version will probably disappear in the near future.
-	IMAGEMAGICK_VERSION='6.9.8-8'
+	IMAGEMAGICK_VERSION='7.0.4-10'
 fi
 
 # Based on http://stackoverflow.com/a/41138688/664741

--- a/bin/install-imagick.sh
+++ b/bin/install-imagick.sh
@@ -6,6 +6,10 @@ set -ex
 IMAGEMAGICK_VERSION='6.9.7-10'
 IMAGICK_VERSION='3.4.3'
 
+if [[ "$TRAVIS_PHP_VERSION" = '7.1' ]]; then
+	IMAGEMAGICK_VERSION='6.9.8-8'
+fi
+
 # Based on http://stackoverflow.com/a/41138688/664741
 install_imagemagick() {
 	curl -O "https://www.imagemagick.org/download/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz" -f

--- a/bin/install-imagick.sh
+++ b/bin/install-imagick.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-# ImageMagick/Imagick versions to use
+# ImageMagick/Imagick versions to use.
 IMAGEMAGICK_VERSION='6.9.7-10'
 IMAGICK_VERSION='3.4.3'
 
@@ -27,8 +27,8 @@ install_imagemagick() {
 	cd "$TRAVIS_BUILD_DIR"
 }
 
-# Install ImageMagick if the current version isn't up to date
+# Install ImageMagick if the current version isn't up to date.
 PATH="$HOME/opt/$WP_VERSION/$TRAVIS_PHP_VERSION/bin:$PATH" identify -version | grep "$IMAGEMAGICK_VERSION" || install_imagemagick
 
-# Install Imagick for PHP
+# Install Imagick for PHP.
 echo "$HOME/opt/$WP_VERSION/$TRAVIS_PHP_VERSION" | pecl install -f "imagick-$IMAGICK_VERSION"

--- a/bin/install-imagick.sh
+++ b/bin/install-imagick.sh
@@ -6,6 +6,7 @@ set -ex
 IMAGEMAGICK_VERSION='6.9.7-10'
 IMAGICK_VERSION='3.4.3'
 
+# Based on http://stackoverflow.com/a/41138688/664741
 install_imagemagick() {
 	curl -O "https://www.imagemagick.org/download/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz" -f
 	tar xf "ImageMagick-$IMAGEMAGICK_VERSION.tar.xz"

--- a/bin/install-imagick.sh
+++ b/bin/install-imagick.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# ImageMagick/Imagick versions to use
+IMAGEMAGICK_VERSION='6.9.7-10'
+IMAGICK_VERSION='3.4.3'
+
+install_imagemagick() {
+	curl -O "https://www.imagemagick.org/download/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz" -f
+	tar xf "ImageMagick-$IMAGEMAGICK_VERSION.tar.xz"
+	rm "ImageMagick-$IMAGEMAGICK_VERSION.tar.xz"
+	cd "ImageMagick-$IMAGEMAGICK_VERSION"
+
+	./configure --prefix="$HOME/opt/$TRAVIS_PHP_VERSION" --with-perl=no
+	make
+	make install
+
+	# Don't need doc - saves around 24M.
+	if [[ -d "$HOME/opt/$TRAVIS_PHP_VERSION/share/doc" ]]; then rm -rf "$HOME/opt/$TRAVIS_PHP_VERSION/share/doc"; fi
+
+	cd "$TRAVIS_BUILD_DIR"
+}
+
+# Install ImageMagick if the current version isn't up to date
+PATH="$HOME/opt/$TRAVIS_PHP_VERSION/bin:$PATH" identify -version | grep "$IMAGEMAGICK_VERSION" || install_imagemagick
+
+# Install Imagick for PHP
+echo "$HOME/opt/$TRAVIS_PHP_VERSION" | pecl install -f "imagick-$IMAGICK_VERSION"


### PR DESCRIPTION
Issue https://github.com/wp-cli/media-command/issues/7

Install Imagick for all versions of PHP so that PDF preview tests run. Use ImageMagick 6.9.7-10 for all except PHP 7.1, which uses 7.0.4-10 to avoid seg faults.