### PR TITLE
--allow_unsafe

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -14,6 +14,17 @@ Feature: Manage WordPress attachments
       Success: Imported 1 of 1 images.
       """
 
+  Scenario: Import image from remote (unsafe) URL
+    When I run `wp media import 'http://wp-cli.org/behat-data/codeispoetry.png' --allow_unsafe`
+    Then STDOUT should contain:
+      """
+      Imported file 'http://wp-cli.org/behat-data/codeispoetry.png'
+      """
+    And STDOUT should contain:
+      """
+      Success: Imported 1 of 1 images.
+      """
+
   Scenario: Fail to import missing image
     When I try `wp media import gobbledygook.png`
     Then STDERR should be:

--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -22,7 +22,7 @@ Feature: Manage WordPress attachments
       """
     And STDOUT should contain:
       """
-      Success: Imported 1 of 1 images.
+      Success: Imported 1 of 1
       """
 
   Scenario: Fail to import missing image

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -238,7 +238,7 @@ class Media_Command extends WP_CLI_Command {
 				}
 				$tempfile = $this->make_copy( $file );
 			} else {
-				$tempfile = $this->download_url( $file, null, $reject_unsafe, \WP_CLI\Utils\get_flag_value( $assoc_args, 'allow_unsafe' ) );
+				$tempfile = $this->download_url( $file, null, \WP_CLI\Utils\get_flag_value( $assoc_args, 'allow_unsafe' ) );
 				if ( is_wp_error( $tempfile ) ) {
 					WP_CLI::warning( sprintf(
 						"Unable to import file '%s'. Reason: %s",
@@ -635,8 +635,11 @@ class Media_Command extends WP_CLI_Command {
 	        if ( ! $tmpfname )
 	                return new WP_Error('http_no_file', __('Could not create Temporary file.'));
 
-	        $reject_unsafe = !$allow_unsafe;
-	        $response = wp_safe_remote_get( $url, array( 'timeout' => $timeout, 'stream' => true, 'filename' => $tmpfname, 'reject_unsafe_urls' => $reject_unsafe ) );
+	        if ( $allow_unsafe ) {
+	        	$response = wp_remote_get( $url, array( 'timeout' => $timeout, 'stream' => true, 'filename' => $tmpfname ) );
+	        } else {
+	        	$response = wp_safe_remote_get( $url, array( 'timeout' => $timeout, 'stream' => true, 'filename' => $tmpfname ) );
+	        }
 
 	        if ( is_wp_error( $response ) ) {
 	                unlink( $tmpfname );

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -173,6 +173,9 @@ class Media_Command extends WP_CLI_Command {
 	 * [--desc=<description>]
 	 * : "Description" field (post content) of attachment post.
 	 *
+	 * [--allow_unsafe]
+	 * : If set, bypasses the `reject_unsafe_urls` check; required when importing from remote domain not publically resolvable.
+	 *
 	 * [--featured_image]
 	 * : If set, set the imported image as the Featured Image of the post its attached to.
 	 *
@@ -211,6 +214,7 @@ class Media_Command extends WP_CLI_Command {
 			'caption' => '',
 			'alt' => '',
 			'desc' => '',
+			''
 		) );
 
 		if ( isset( $assoc_args['post_id'] ) ) {
@@ -235,7 +239,7 @@ class Media_Command extends WP_CLI_Command {
 				}
 				$tempfile = $this->make_copy( $file );
 			} else {
-				$tempfile = download_url( $file );
+				$tempfile = $this->download_url( $file, null, $reject_unsafe, \WP_CLI\Utils\get_flag_value( $assoc_args, 'allow_unsafe' ) );
 				if ( is_wp_error( $tempfile ) ) {
 					WP_CLI::warning( sprintf(
 						"Unable to import file '%s'. Reason: %s",
@@ -607,5 +611,53 @@ class Media_Command extends WP_CLI_Command {
 			// Treat removing unused metadata as no change.
 		}
 		return false;
+	}
+
+	/**
+	 * Custom version of download_url() that accepts reject_unsafe_urls arg.
+	 *
+	 * Downloads a URL to a local temporary file using the WordPress HTTP Class.
+	 * Please note, That the calling function must unlink() the file.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @param string $url the URL of the file to download
+	 * @param int $timeout The timeout for the request to download the file default 300 seconds
+	 * @return mixed WP_Error on failure, string Filename on success.
+	 */
+	private function download_url( $url, $timeout = 300, $allow_unsafe = false ) {
+	        //WARNING: The file is not automatically deleted, The script must unlink() the file.
+	        if ( ! $url )
+	                return new WP_Error('http_no_url', __('Invalid URL Provided.'));
+
+	        $url_filename = basename( parse_url( $url, PHP_URL_PATH ) );
+
+	        $tmpfname = wp_tempnam( $url_filename );
+	        if ( ! $tmpfname )
+	                return new WP_Error('http_no_file', __('Could not create Temporary file.'));
+
+	        $reject_unsafe = !$allow_unsafe;
+	        $response = wp_safe_remote_get( $url, array( 'timeout' => $timeout, 'stream' => true, 'filename' => $tmpfname, 'reject_unsafe_urls' => $reject_unsafe ) );
+
+	        if ( is_wp_error( $response ) ) {
+	                unlink( $tmpfname );
+	                return $response;
+	        }
+
+	        if ( 200 != wp_remote_retrieve_response_code( $response ) ){
+	                unlink( $tmpfname );
+	                return new WP_Error( 'http_404', trim( wp_remote_retrieve_response_message( $response ) ) );
+	        }
+
+	        $content_md5 = wp_remote_retrieve_header( $response, 'content-md5' );
+	        if ( $content_md5 ) {
+	                $md5_check = verify_file_md5( $tmpfname, $content_md5 );
+	                if ( is_wp_error( $md5_check ) ) {
+	                        unlink( $tmpfname );
+	                        return $md5_check;
+	                }
+	        }
+
+	        return $tmpfname;
 	}
 }

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -620,20 +620,23 @@ class Media_Command extends WP_CLI_Command {
 	 *
 	 * @since 2.5.0
 	 *
-	 * @param string $url the URL of the file to download
-	 * @param int $timeout The timeout for the request to download the file default 300 seconds
+	 * @param string $url The URL of the file to download.
+	 * @param int    $timeout The timeout for the request to download the file default 300 seconds.
+	 * @param bool   $allow_unsafe Whether to run reject_unsafe_urls check.
 	 * @return mixed WP_Error on failure, string Filename on success.
 	 */
 	private function download_url( $url, $timeout = 300, $allow_unsafe = false ) {
-	        //WARNING: The file is not automatically deleted, The script must unlink() the file.
-	        if ( ! $url )
-	                return new WP_Error('http_no_url', __('Invalid URL Provided.'));
+	        // WARNING: The file is not automatically deleted, The script must unlink() the file.
+	        if ( ! $url ) {
+				return new WP_Error( 'http_no_url', __( 'Invalid URL Provided.' ) );
+	        }
 
 	        $url_filename = basename( parse_url( $url, PHP_URL_PATH ) );
 
 	        $tmpfname = wp_tempnam( $url_filename );
-	        if ( ! $tmpfname )
-	                return new WP_Error('http_no_file', __('Could not create Temporary file.'));
+	        if ( ! $tmpfname ) {
+				return new WP_Error( 'http_no_file', __( 'Could not create Temporary file.' ) );
+	        }
 
 	        if ( $allow_unsafe ) {
 	        	$response = wp_remote_get( $url, array( 'timeout' => $timeout, 'stream' => true, 'filename' => $tmpfname ) );
@@ -646,7 +649,7 @@ class Media_Command extends WP_CLI_Command {
 	                return $response;
 	        }
 
-	        if ( 200 != wp_remote_retrieve_response_code( $response ) ){
+	        if ( 200 != wp_remote_retrieve_response_code( $response ) ) {
 	                unlink( $tmpfname );
 	                return new WP_Error( 'http_404', trim( wp_remote_retrieve_response_message( $response ) ) );
 	        }

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -214,7 +214,6 @@ class Media_Command extends WP_CLI_Command {
 			'caption' => '',
 			'alt' => '',
 			'desc' => '',
-			''
 		) );
 
 		if ( isset( $assoc_args['post_id'] ) ) {

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -113,20 +113,19 @@ class Media_Command extends WP_CLI_Command {
 			'post_mime_type' => $mime_types,
 			'post_status' => 'any',
 			'posts_per_page' => -1,
-			'fields' => 'ids'
+			'fields' => 'ids',
 		);
 
 		$images = new WP_Query( $query_args );
 
 		$count = $images->post_count;
 
-		if ( !$count ) {
+		if ( ! $count ) {
 			WP_CLI::warning( 'No images found.' );
 			return;
 		}
 
-		WP_CLI::log( sprintf( 'Found %1$d %2$s to regenerate.', $count,
-			_n( 'image', 'images', $count ) ) );
+		WP_CLI::log( sprintf( 'Found %1$d %2$s to regenerate.', $count, _n( 'image', 'images', $count ) ) );
 
 		if ( $image_size ) {
 			$image_size_filters = $this->add_image_size_filters( $image_size );
@@ -215,8 +214,8 @@ class Media_Command extends WP_CLI_Command {
 		) );
 
 		if ( isset( $assoc_args['post_id'] ) ) {
-			if ( !get_post( $assoc_args['post_id'] ) ) {
-				WP_CLI::warning( "Invalid --post_id" );
+			if ( ! get_post( $assoc_args['post_id'] ) ) {
+				WP_CLI::warning( 'Invalid --post_id' );
 				$assoc_args['post_id'] = false;
 			}
 		} else {
@@ -229,7 +228,7 @@ class Media_Command extends WP_CLI_Command {
 			$orig_filename = $file;
 
 			if ( empty( $is_file_remote ) ) {
-				if ( !file_exists( $file ) ) {
+				if ( ! file_exists( $file ) ) {
 					WP_CLI::warning( "Unable to import file '$file'. Reason: File doesn't exist." );
 					$errors++;
 					continue;
@@ -249,17 +248,17 @@ class Media_Command extends WP_CLI_Command {
 
 			$file_array = array(
 				'tmp_name' => $tempfile,
-				'name' => Utils\basename( $file )
+				'name' => Utils\basename( $file ),
 			);
 
-			$post_array= array(
+			$post_array = array(
 				'post_title' => $assoc_args['title'],
 				'post_excerpt' => $assoc_args['caption'],
-				'post_content' => $assoc_args['desc']
+				'post_content' => $assoc_args['desc'],
 			);
 			$post_array = wp_slash( $post_array );
 
-			// use image exif/iptc data for title and caption defaults if possible
+			// use image exif/iptc data for title and caption defaults if possible.
 			if ( empty( $post_array['post_title'] ) || empty( $post_array['post_excerpt'] ) ) {
 				// @codingStandardsIgnoreStart
 				$image_meta = @wp_read_image_metadata( $tempfile );
@@ -290,12 +289,12 @@ class Media_Command extends WP_CLI_Command {
 				continue;
 			}
 
-			// Set alt text
+			// Set alt text.
 			if ( $assoc_args['alt'] ) {
 				update_post_meta( $success, '_wp_attachment_image_alt', wp_slash( $assoc_args['alt'] ) );
 			}
 
-			// Set as featured image, if --post_id and --featured_image are set
+			// Set as featured image, if --post_id and --featured_image are set.
 			if ( $assoc_args['post_id'] && \WP_CLI\Utils\get_flag_value( $assoc_args, 'featured_image' ) ) {
 				update_post_meta( $assoc_args['post_id'], '_thumbnail_id', $success );
 			}
@@ -303,8 +302,9 @@ class Media_Command extends WP_CLI_Command {
 			$attachment_success_text = '';
 			if ( $assoc_args['post_id'] ) {
 				$attachment_success_text = " and attached to post {$assoc_args['post_id']}";
-				if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'featured_image' ) )
+				if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'featured_image' ) ) {
 					$attachment_success_text .= ' as featured image';
+				}
 			}
 
 			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
@@ -324,16 +324,18 @@ class Media_Command extends WP_CLI_Command {
 		}
 	}
 
-	// wp_tempnam() inexplicably forces a .tmp extension, which spoils MIME type detection
+	// wp_tempnam() inexplicably forces a .tmp extension, which spoils MIME type detection.
 	private function make_copy( $path ) {
 		$dir = get_temp_dir();
 		$filename = Utils\basename( $path );
-		if ( empty( $filename ) )
+		if ( empty( $filename ) ) {
 			$filename = time();
+		}
 
 		$filename = $dir . wp_unique_filename( $dir, $filename );
-		if ( !copy( $path, $filename ) )
+		if ( ! copy( $path, $filename ) ) {
 			WP_CLI::error( "Could not create temporary file for $path." );
+		}
 
 		return $filename;
 	}
@@ -344,7 +346,7 @@ class Media_Command extends WP_CLI_Command {
 		$att_desc = sprintf( '"%1$s" (ID %2$d)', get_the_title( $id ), $id );
 		$thumbnail_desc = $image_size ? sprintf( '"%s" thumbnail', $image_size ) : 'thumbnail';
 
-		if ( false === $fullsizepath || !file_exists( $fullsizepath ) ) {
+		if ( false === $fullsizepath || ! file_exists( $fullsizepath ) ) {
 			WP_CLI::warning( "Can't find $att_desc." );
 			return false;
 		}
@@ -406,17 +408,19 @@ class Media_Command extends WP_CLI_Command {
 		foreach ( $metadata['sizes'] as $size_info ) {
 			$intermediate_path = $dir_path . $size_info['file'];
 
-			if ( $intermediate_path === $fullsizepath )
+			if ( $intermediate_path === $fullsizepath ) {
 				continue;
+			}
 
-			if ( file_exists( $intermediate_path ) )
+			if ( file_exists( $intermediate_path ) ) {
 				unlink( $intermediate_path );
+			}
 		}
 	}
 
 	private function needs_regeneration( $att_id, $fullsizepath, $is_pdf, $image_size ) {
 
-		$metadata = wp_get_attachment_metadata($att_id);
+		$metadata = wp_get_attachment_metadata( $att_id );
 
 		// Note that an attachment can have no sizes if it's on or below the thumbnail threshold.
 
@@ -440,11 +444,12 @@ class Media_Command extends WP_CLI_Command {
 		$dir_path = dirname( $fullsizepath ) . '/';
 
 		// Check that the thumbnail files exist.
-		foreach( $metadata['sizes'] as $size_info ) {
+		foreach ( $metadata['sizes'] as $size_info ) {
 			$intermediate_path = $dir_path . $size_info['file'];
 
-			if ( $intermediate_path === $fullsizepath )
+			if ( $intermediate_path === $fullsizepath ) {
 				continue;
+			}
 
 			if ( ! file_exists( $intermediate_path ) ) {
 				return true;


### PR DESCRIPTION
Allow items on local domains / IPs to be imported. Particularly useful when handling sites within a LAN that aren't public.