### PR TITLE
Try ImageMagick 7.0.3-10 for PHP 7.1 and 6.9.6-8 for the rest.

### DIFF
--- a/bin/install-imagick.sh
+++ b/bin/install-imagick.sh
@@ -3,11 +3,11 @@
 set -ex
 
 # ImageMagick/Imagick versions to use.
-IMAGEMAGICK_VERSION='6.9.7-10'
+IMAGEMAGICK_VERSION='6.9.6-8'
 IMAGICK_VERSION='3.4.3'
 
-if [[ "$TRAVIS_PHP_VERSION" = '7.1' ]]; then
-	IMAGEMAGICK_VERSION='7.0.4-10'
+if [[ "$TRAVIS_PHP_VERSION" = 7.1 ]]; then
+	IMAGEMAGICK_VERSION='7.0.3-10'
 fi
 
 # Based on http://stackoverflow.com/a/41138688/664741


### PR DESCRIPTION
Issue https://github.com/wp-cli/media-command/issues/7

Related https://github.com/wp-cli/media-command/pull/21, and its PHP 7.1 seg fault failure.

More ImageMagick version bingo. These versions seem to be more stable on testing.