### PR TITLE
Make regen tests indifferent to process order.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 *.zip
 *.tar.gz
 composer.lock
+.*.swp

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -227,11 +227,11 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      1/2 No thumbnail regeneration needed for "My second imported attachment"
+      /2 No thumbnail regeneration needed for "My second imported attachment"
       """
     And STDOUT should contain:
       """
-      2/2 Regenerated thumbnails for "My imported attachment"
+      /2 Regenerated thumbnails for "My imported attachment"
       """
     And STDOUT should contain:
       """
@@ -246,11 +246,11 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      1/2 No thumbnail regeneration needed for "My second imported attachment"
+      /2 No thumbnail regeneration needed for "My second imported attachment"
       """
     And STDOUT should contain:
       """
-      2/2 No thumbnail regeneration needed for "My imported attachment"
+      /2 No thumbnail regeneration needed for "My imported attachment"
       """
     And STDOUT should contain:
       """
@@ -278,11 +278,11 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      1/2 Regenerated thumbnails for "My second imported attachment"
+      /2 Regenerated thumbnails for "My second imported attachment"
       """
     And STDOUT should contain:
       """
-      2/2 Regenerated thumbnails for "My imported attachment"
+      /2 Regenerated thumbnails for "My imported attachment"
       """
     And STDOUT should contain:
       """


### PR DESCRIPTION
Makes the `media-regenerate.feature` tests agnostic as to the processing order of items by removing the order no. from the expected output, as it's indeterminate and can fail locally depending on db setup/version.