### PR TITLE
Replicate wp_get_additional_image_sizes() for WP < 4.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest
     - php: 5.6
-      env: WP_VERSION=trunk
+      env: WP_VERSION=3.7.11
     - php: 5.3
       env: WP_VERSION=latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=3.7.11
+    - php: 5.6
+      env: WP_VERSION=trunk
     - php: 5.3
       env: WP_VERSION=latest
 

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -207,6 +207,15 @@ Feature: Regenerate WordPress attachments
       add_action( 'after_setup_theme', function(){
         add_image_size( 'test1', 125, 125, true );
       });
+      // Handle WP < 4.4 when there was no dash before numbers (changeset 35276).
+      add_filter( 'wp_handle_upload', function ( $info, $upload_type = null ) {
+        if ( ( $new_file = str_replace( 'image1.jpg', 'image-1.jpg', $info['file'] ) ) !== $info['file'] ) {
+            rename( $info['file'], $new_file );
+            $info['file'] = $new_file;
+            $info['url'] = str_replace( 'image1.jpg', 'image-1.jpg', $info['url'] );
+        }
+        return $info;
+      } );
       """
     And I run `wp option update uploads_use_yearmonth_folders 0`
 
@@ -264,15 +273,6 @@ Feature: Regenerate WordPress attachments
       add_action( 'after_setup_theme', function(){
         add_image_size( 'test1', 200, 200, true );
       });
-      // Handle WP < 4.4 when there was no dash before numbers (changeset 35276).
-      add_filter( 'wp_handle_upload', function ( $info, $upload_type = null ) {
-        if ( ( $new_file = str_replace( 'image1.jpg', 'image-1.jpg', $info['file'] ) ) !== $info['file'] ) {
-            rename( $info['file'], $new_file );
-            $info['file'] = $new_file;
-            $info['url'] = str_replace( 'image1.jpg', 'image-1.jpg', $info['url'] );
-        }
-        return $info;
-      } );
       """
     Then the wp-content/uploads/large-image-125x125.jpg file should exist
     And the wp-content/uploads/large-image-1-125x125.jpg file should exist

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -547,7 +547,16 @@ class Media_Command extends WP_CLI_Command {
 
 		// Adapted from wp_generate_attachment_metadata() in "wp-admin/includes/image.php".
 
-		$_wp_additional_image_sizes = wp_get_additional_image_sizes();
+		if ( function_exists( 'wp_get_additional_image_sizes' ) ) {
+			$_wp_additional_image_sizes = wp_get_additional_image_sizes();
+		} else {
+			// For WP < 4.7.0.
+			global $_wp_additional_image_sizes;
+			if ( ! $_wp_additional_image_sizes ) {
+				$_wp_additional_image_sizes = array();
+			}
+		}
+
 
 		$sizes = array();
 		foreach ( $intermediate_image_sizes as $s ) {


### PR DESCRIPTION
`wp_get_additional_image_sizes()` introduced WP 4.7 so replicate it for BC.

Edit:

Also adds BC workaround for WP < 4.4 when there was no dash before numbers in filenames (changeset [35276](https://core.trac.wordpress.org/changeset/35276)).

Also adds BC workaround for WP < 4.2 when `Imagick` image editor produced thumbnails when it shouldn't (changeset [31576](https://core.trac.wordpress.org/changeset/31576)).

Also changes Travis to run WP 3.7.11 instead of trunk on PHP 5.6 job as it's more useful I think to catch these BC issues early - maybe do this for all commands?