### PR TITLE
Use a more helpful description for `wp media *`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-cli/media-command",
-    "description": "Import and regenerate attachments.",
+    "description": "Import new attachments or regenerate existing ones.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/media-command",
     "support": {

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -3,7 +3,7 @@
 use WP_CLI\Utils;
 
 /**
- * Manage attachments.
+ * Import new attachments or regenerate existing.
  *
  * ## EXAMPLES
  *

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -3,7 +3,7 @@
 use WP_CLI\Utils;
 
 /**
- * Import new attachments or regenerate existing.
+ * Import new attachments or regenerate existing ones.
  *
  * ## EXAMPLES
  *


### PR DESCRIPTION
From:

> Manage attachments.

To:

> Import new attachments or regenerate existing.