### PR TITLE
Use `dist: precise` for PHP 5.3, `dist: trusty` for everything else

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 language: php
 
@@ -34,6 +35,7 @@ matrix:
     - php: 5.6
       env: WP_VERSION=trunk
     - php: 5.3
+      dist: precise
       env: WP_VERSION=latest
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 dist: trusty
 
 language: php
@@ -36,10 +36,13 @@ matrix:
       env: WP_VERSION=trunk
     - php: 5.3
       dist: precise
+      sudo: false
       env: WP_VERSION=latest
 
 before_install:
   - phpenv config-rm xdebug.ini
+  - bash bin/install-ghostscript.sh
+  - gs -v
   - bash bin/install-imagick.sh
   - php -m
 

--- a/bin/install-ghostscript.sh
+++ b/bin/install-ghostscript.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [[ "$TRAVIS_PHP_VERSION" != 5.3 ]]; then
+	sudo apt-get -qq update
+	sudo apt-get install -y ghostscript
+fi
+


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/4218