### PR TITLE
Handle query strings on URL import.

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -14,6 +14,17 @@ Feature: Manage WordPress attachments
       Success: Imported 1 of 1 items.
       """
 
+  Scenario: Import media from remote URL with query string
+    When I run `wp media import 'http://via.placeholder.com/350x150.jpg?text=Foo'`
+    Then STDOUT should contain:
+      """
+      Imported file 'http://via.placeholder.com/350x150.jpg?text=Foo' as attachment ID 86.
+      """
+    And STDOUT should contain:
+      """
+      Success: Imported 1 of 1 items.
+      """
+
   Scenario: Fail to import missing image
     When I try `wp media import gobbledygook.png`
     Then STDERR should be:

--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -18,7 +18,7 @@ Feature: Manage WordPress attachments
     When I run `wp media import 'http://via.placeholder.com/350x150.jpg?text=Foo'`
     Then STDOUT should contain:
       """
-      Imported file 'http://via.placeholder.com/350x150.jpg?text=Foo' as attachment ID 86.
+      Imported file 'http://via.placeholder.com/350x150.jpg?text=Foo' as attachment ID
       """
     And STDOUT should contain:
       """

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -250,6 +250,7 @@ class Media_Command extends WP_CLI_Command {
 				} else {
 					$tempfile = $this->make_copy( $file );
 				}
+				$name = Utils\basename( $file );
 			} else {
 				$tempfile = download_url( $file );
 				if ( is_wp_error( $tempfile ) ) {
@@ -260,11 +261,12 @@ class Media_Command extends WP_CLI_Command {
 					$errors++;
 					continue;
 				}
+				$name = strtok( Utils\basename( $file ), '?' );
 			}
 
 			$file_array = array(
 				'tmp_name' => $tempfile,
-				'name' => Utils\basename( $file )
+				'name' => $name,
 			);
 
 			$post_array= array(


### PR DESCRIPTION
If you're trying to import an image with a query string (such as from [Placeholder.com](http://placeholder.com) using custom copy), WordPress says `Sorry, this file type is not permitted for security reasons.` because the query string makes it all the way to file name, so the file fails validation.

This PR strips the query string when passing it along, and only does the operation if the file is remote.