### PR TITLE
Rename `wp media sizes` to `wp media image-size`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,12 @@ wp media regenerate [<attachment-id>...] [--image_size=<image_size>] [--skip-del
 
 
 
-### wp media sizes
+### wp media image-size
 
-List media sizes registered with WordPress.
+List image sizes registered with WordPress.
 
 ~~~
-wp media sizes [--fields=<fields>] [--format=<format>]
+wp media image-size [--fields=<fields>] [--format=<format>]
 ~~~
 
 **OPTIONS**
@@ -177,7 +177,7 @@ These fields will be displayed by default for each image size:
 **EXAMPLES**
 
     # List all registered image sizes
-    $ wp media sizes
+    $ wp media image-size
     +---------------------------+-------+--------+-------+
     | name                      | width | height | crop  |
     +---------------------------+-------+--------+-------+

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "commands": [
             "media import",
             "media regenerate",
-            "media sizes"
+            "media image-size"
         ],
         "bundled": true
     }

--- a/features/media-image-size.feature
+++ b/features/media-image-size.feature
@@ -1,9 +1,9 @@
-Feature: List media sizes
+Feature: List image sizes
 
   Scenario: Basic usage
     Given a WP install
 
-    When I run `wp media sizes`
+    When I run `wp media image-size`
     Then STDOUT should be a table containing rows:
       | name       | width     | height    | crop   |
       | full       |           |           | false  |

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -361,7 +361,7 @@ class Media_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * List media sizes registered with WordPress.
+	 * List image sizes registered with WordPress.
 	 *
 	 * ## OPTIONS
 	 *
@@ -391,7 +391,7 @@ class Media_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     # List all registered image sizes
-	 *     $ wp media sizes
+	 *     $ wp media image-size
 	 *     +---------------------------+-------+--------+-------+
 	 *     | name                      | width | height | crop  |
 	 *     +---------------------------+-------+--------+-------+
@@ -402,8 +402,10 @@ class Media_Command extends WP_CLI_Command {
 	 *     | medium                    | 300   | 300    | true  |
 	 *     | thumbnail                 | 150   | 150    | true  |
 	 *     +---------------------------+-------+--------+-------+
+	 *
+	 * @subcommand image-size
 	 */
-	public function sizes( $args, $assoc_args ) {
+	public function image_size( $args, $assoc_args ) {
 		global $_wp_additional_image_sizes;
 
 		$assoc_args = array_merge( array(


### PR DESCRIPTION
Singular over plural, and `image-size` over `sizes` to distinguish from
existing `wp db size`