### PR TITLE
Add `--preserve-filetime` argument to support persisting file modification time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package implements the following commands:
 Create attachments from local files or URLs.
 
 ~~~
-wp media import <file>... [--post_id=<post_id>] [--title=<title>] [--caption=<caption>] [--alt=<alt_text>] [--desc=<description>] [--skip-copy] [--featured_image] [--porcelain]
+wp media import <file>... [--post_id=<post_id>] [--title=<title>] [--caption=<caption>] [--alt=<alt_text>] [--desc=<description>] [--skip-copy] [--preserve-filetime] [--featured_image] [--porcelain]
 ~~~
 
 **OPTIONS**
@@ -43,6 +43,10 @@ wp media import <file>... [--post_id=<post_id>] [--title=<title>] [--caption=<ca
 
 	[--skip-copy]
 		If set, media files (local only) are imported to the library but not moved on disk.
+
+	[--preserve-filetime]
+		Use the file modified time as the post published & modified dates.
+		Remote files will always use the current time.
 
 	[--featured_image]
 		If set, set the imported image as the Featured Image of the post its attached to.
@@ -181,12 +185,12 @@ These fields will be displayed by default for each image size:
     +---------------------------+-------+--------+-------+
     | name                      | width | height | crop  |
     +---------------------------+-------+--------+-------+
-    | full                      |       |        | false |
-    | twentyfourteen-full-width | 1038  | 576    | true  |
-    | large                     | 1024  | 1024   | true  |
-    | post-thumbnail            | 672   | 372    | true  |
-    | medium                    | 300   | 300    | true  |
-    | thumbnail                 | 150   | 150    | true  |
+    | full                      |       |        | N/A   |
+    | twentyfourteen-full-width | 1038  | 576    | hard  |
+    | large                     | 1024  | 1024   | soft  |
+    | medium_large              | 768   | 0      | soft  |
+    | medium                    | 300   | 300    | soft  |
+    | thumbnail                 | 150   | 150    | hard  |
     +---------------------------+-------+--------+-------+
 
 ## Installing

--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -60,6 +60,27 @@ Feature: Manage WordPress attachments
     And the {CACHE_DIR}/large-image.jpg file should exist
     And the return code should be 0
 
+  Scenario: Import a file as attachment from a local image and preserve the file modified time.
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+    And I run `touch -m 1505787257 {CACHE_DIR}/large-image.jpg`
+    And I run `wp option update gmt_offset -5`
+    And I run `wp media import {CACHE_DIR}/large-image.jpg --post_id=1 --filetime`
+    And I run `wp post get 1 --field=post_date`
+    Then STDOUT should be:
+      """
+      1999-12-31 19:00:00
+      """
+
+    When I run `wp post get 1 --field=post_date_gmt`
+    Then STDOUT should be:
+      """
+      2000-01-01 00:00:00
+      """
+
+    And the return code should be 0
+
   Scenario: Import a file as an attachment but porcelain style
     Given download:
       | path                        | url                                              |

--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -64,22 +64,23 @@ Feature: Manage WordPress attachments
     Given download:
       | path                        | url                                              |
       | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
-    And I run `touch -m 1505787257 {CACHE_DIR}/large-image.jpg`
+    And I run `TZ=UTC touch -t 8001031305 {CACHE_DIR}/large-image.jpg`
     And I run `wp option update gmt_offset -5`
-    And I run `wp media import {CACHE_DIR}/large-image.jpg --post_id=1 --filetime`
-    And I run `wp post get 1 --field=post_date`
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --post_id=1 --preserve-filetime --porcelain`
+    Then save STDOUT as {ATTACH_ID}
+
+    And I run `wp post get {ATTACH_ID} --field=post_date`
     Then STDOUT should be:
       """
-      1999-12-31 19:00:00
+      1980-01-03 08:05:00
       """
 
-    When I run `wp post get 1 --field=post_date_gmt`
+    When I run `wp post get {ATTACH_ID} --field=post_date_gmt`
     Then STDOUT should be:
       """
-      2000-01-01 00:00:00
+      1980-01-03 13:05:00
       """
-
-    And the return code should be 0
 
   Scenario: Import a file as an attachment but porcelain style
     Given download:

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -172,15 +172,15 @@ class Media_Command extends WP_CLI_Command {
 	 * [--skip-copy]
 	 * : If set, media files (local only) are imported to the library but not moved on disk.
 	 *
+	 * [--preserve-filetime]
+	 * : Use the file modified time as the post published & modified dates.
+	 * Remote files will always use the current time.
+	 *
 	 * [--featured_image]
 	 * : If set, set the imported image as the Featured Image of the post its attached to.
 	 *
 	 * [--porcelain]
 	 * : Output just the new attachment ID.
-	 *
-	 * [--filetime]
-	 * : Use the file modified time as the post published & modified dates.
-	 *     Remote files will always use the current time.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -255,7 +255,7 @@ class Media_Command extends WP_CLI_Command {
 				}
 				$name = Utils\basename( $file );
 
-				if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'filetime' ) ) {
+				if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'preserve-filetime' ) ) {
 					$file_time = @filemtime( $file );
 				}
 			} else {

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -288,9 +288,9 @@ class Media_Command extends WP_CLI_Command {
 			);
 
 			if ( ! empty( $file_time ) ) {
-				$post_array['post_date'] = gmdate( 'Y-m-d H:i:s', $file_time + ( $gmt_offset * 60 * 60 ) );
+				$post_array['post_date'] = gmdate( 'Y-m-d H:i:s', $file_time + ( $gmt_offset * HOUR_IN_SECONDS ) );
 				$post_array['post_date_gmt'] = gmdate( 'Y-m-d H:i:s', $file_time );
-				$post_array['post_modified'] = gmdate( 'Y-m-d H:i:s', $file_time + ( $gmt_offset * 60 * 60 ) );
+				$post_array['post_modified'] = gmdate( 'Y-m-d H:i:s', $file_time + ( $gmt_offset * HOUR_IN_SECONDS ) );
 				$post_array['post_modified_gmt'] = gmdate( 'Y-m-d H:i:s', $file_time );
 			}
 


### PR DESCRIPTION
As detailed in #41, preserving the file time when importing local files could be very useful.

This PR introduces the `--preserve-filetime` option to use the file modified time instead of the default current time.

This is missing tests as I have not written Behat tests before. I will add those shortly as soon as I can read up a bit and get them running locally.

Fixes #41 