### PR TITLE
Skip non-thumbnailed PDFS & other images rather than fail. Check retu…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ matrix:
     - php: 5.3
       dist: precise
       env: WP_VERSION=latest
+    - php: 5.6
+      env: WP_VERSION=3.9
+    - php: 5.6
+      env: WP_VERSION=4.2
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ matrix:
     - php: 5.3
       dist: precise
       env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=3.9
-    - php: 5.6
-      env: WP_VERSION=4.2
 
 before_install:
   - |

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -1150,9 +1150,9 @@ Feature: Regenerate WordPress attachments
   @require-wp-3.9
   Scenario: Regenerating audio with thumbnail
     Given download:
-      | path                                     | url                                                              |
-      | {CACHE_DIR}/audio-with-400x300-cover.mp3 | http://gitlostbonger.com/behat-data/audio-with-400x300-cover.mp3 |
-      | {CACHE_DIR}/audio-with-no-cover.mp3      | http://gitlostbonger.com/behat-data/audio-with-no-cover.mp3      |
+      | path                                     | url                                                       |
+      | {CACHE_DIR}/audio-with-400x300-cover.mp3 | http://wp-cli.org/behat-data/audio-with-400x300-cover.mp3 |
+      | {CACHE_DIR}/audio-with-no-cover.mp3      | http://wp-cli.org/behat-data/audio-with-no-cover.mp3      |
     And a wp-content/mu-plugins/media-settings.php file:
       """
       <?php add_post_type_support( 'attachment:audio', 'thumbnail' );
@@ -1206,9 +1206,9 @@ Feature: Regenerate WordPress attachments
   @require-wp-4.3
   Scenario: Regenerating video with thumbnail
     Given download:
-      | path                                        | url                                                                 |
-      | {CACHE_DIR}/video-400x300-with-cover.mp4    | http://gitlostbonger.com/behat-data/video-400x300-with-cover.mp4    |
-      | {CACHE_DIR}/video-400x300-with-no-cover.mp4 | http://gitlostbonger.com/behat-data/video-400x300-with-no-cover.mp4 |
+      | path                                        | url                                                          |
+      | {CACHE_DIR}/video-400x300-with-cover.mp4    | http://wp-cli.org/behat-data/video-400x300-with-cover.mp4    |
+      | {CACHE_DIR}/video-400x300-with-no-cover.mp4 | http://wp-cli.org/behat-data/video-400x300-with-no-cover.mp4 |
     And a stderr-error-log.php file:
       """
       <?php
@@ -1258,10 +1258,10 @@ Feature: Regenerate WordPress attachments
   @require-wp-4.7.3 @require-extension-imagick
   Scenario: Regenerating melange with batch results: regenerated (and not needing regeneration), skipped, failed
     Given download:
-      | path                                     | url                                                              |
-      | {CACHE_DIR}/canola.jpg                   | http://wp-cli.org/behat-data/canola.jpg                          |
-      | {CACHE_DIR}/minimal-us-letter.pdf        | http://wp-cli.org/behat-data/minimal-us-letter.pdf               |
-      | {CACHE_DIR}/video-400x300-with-cover.mp4 | http://gitlostbonger.com/behat-data/video-400x300-with-cover.mp4 |
+      | path                                     | url                                                       |
+      | {CACHE_DIR}/canola.jpg                   | http://wp-cli.org/behat-data/canola.jpg                   |
+      | {CACHE_DIR}/minimal-us-letter.pdf        | http://wp-cli.org/behat-data/minimal-us-letter.pdf        |
+      | {CACHE_DIR}/video-400x300-with-cover.mp4 | http://wp-cli.org/behat-data/video-400x300-with-cover.mp4 |
     And an svg.svg file:
       """
       <svg xmlns="http://www.w3.org/2000/svg"/>

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -1147,9 +1147,12 @@ Feature: Regenerate WordPress attachments
     And STDERR should be empty
 
   # Audio/video `_cover_hash` meta, used to determine if sub attachment, added in WP 3.9
-  @require-wp-3.9
-  Scenario: Regenerating audio with thumbnail
-    Given download:
+  # Test on PHP 5.6 latest only, and iterate over various WP versions.
+  @require-wp-latest @require-php-5.6 @less-than-php-7.0
+  Scenario Outline: Regenerating audio with thumbnail
+	Given I run `wp core download --version=<version> --force`
+	And I run `wp core update-db`
+    And download:
       | path                                     | url                                                       |
       | {CACHE_DIR}/audio-with-400x300-cover.mp3 | http://wp-cli.org/behat-data/audio-with-400x300-cover.mp3 |
       | {CACHE_DIR}/audio-with-no-cover.mp3      | http://wp-cli.org/behat-data/audio-with-no-cover.mp3      |
@@ -1201,6 +1204,13 @@ Feature: Regenerate WordPress attachments
       Success: Regenerated 1 of 1 images.
       """
     And STDERR should be empty
+
+    Examples:
+      | version |
+      | latest  |
+      | trunk   |
+      | 4.2     |
+      | 3.9     |
 
   # Video cover support requires ID3 library 1.9.9, updated WP 4.3 https://core.trac.wordpress.org/ticket/32806
   @require-wp-4.3

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -614,10 +614,6 @@ class Media_Command extends WP_CLI_Command {
 			WP_CLI::warning( $image_sizes->get_error_message() );
 			return true;
 		}
-		if ( ! $image_sizes ) {
-			// This shouldn't really happen so assume that it may be possible to regenerate and allow processing to continue and possibly fail.
-			return true;
-		}
 
 		if ( $image_size ) {
 			if ( empty( $image_sizes[ $image_size ] ) ) {

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -141,7 +141,7 @@ class Media_Command extends WP_CLI_Command {
 			$this->remove_image_size_filters( $image_size_filters );
 		}
 
-		self::report_batch_operation_results( 'image', 'regenerate', $count, $successes, $errors, $skips );
+		Utils\report_batch_operation_results( 'image', 'regenerate', $count, $successes, $errors, $skips );
 	}
 
 	/**
@@ -523,7 +523,7 @@ class Media_Command extends WP_CLI_Command {
 			return;
 		}
 
-		// Note it's possible for no metadata to generated for PDFs if restricted to a specific image size.
+		// Note it's possible for no metadata to be generated for PDFs if restricted to a specific image size.
 		if ( empty( $metadata ) && ! ( $is_pdf && $image_size ) ) {
 			WP_CLI::warning( "$progress Couldn't regenerate thumbnails for $att_desc." );
 			$errors++;
@@ -805,41 +805,6 @@ class Media_Command extends WP_CLI_Command {
 			// Treat removing unused metadata as no change.
 		}
 		return false;
-	}
-
-	/**
-	 * Report the results of the same operation against multiple resources.
-	 *
-	 * @access public
-	 * @category Input
-	 *
-	 * @param string  $noun      Resource being affected (e.g. plugin)
-	 * @param string  $verb      Type of action happening to the noun (e.g. activate)
-	 * @param integer $total     Total number of resource being affected.
-	 * @param integer $successes Number of successful operations.
-	 * @param integer $failures  Number of failures.
-	 * @param integer $skips     Number of skipped operations.
-	 */
-	private function report_batch_operation_results( $noun, $verb, $total, $successes, $failures, $skips = 0 ) {
-		$plural_noun = $noun . 's';
-		$past_tense_verb = Utils\past_tense_verb( $verb );
-		$past_tense_verb_upper = ucfirst( $past_tense_verb );
-		if ( $failures ) {
-			$failed_skipped_message =  " ({$failures} failed" . ( $skips ? ", {$skips} skipped" : '' ) . ')';
-			if ( $successes ) {
-				WP_CLI::error( "Only {$past_tense_verb} {$successes} of {$total} {$plural_noun}{$failed_skipped_message}." );
-			} else {
-				WP_CLI::error( "No {$plural_noun} {$past_tense_verb}{$failed_skipped_message}." );
-			}
-		} else {
-			$skipped_message = $skips ? " ({$skips} skipped)" : '';
-			if ( $successes || $skips ) {
-				WP_CLI::success( "{$past_tense_verb_upper} {$successes} of {$total} {$plural_noun}{$skipped_message}." );
-			} else {
-				$message = $total > 1 ? ucfirst( $plural_noun ) : ucfirst( $noun );
-				WP_CLI::success( "{$message} already {$past_tense_verb}." );
-			}
-		}
 	}
 
 }


### PR DESCRIPTION
Fixes #25 
Fixes #43

For discussion.

Skips rather than fails when PDF thumbnails are not available or when images such as SVGs are encountered.

Some re-factoring is involved re changing `process_regeneration()` to take extra args `$successes, $errors, $skips` rather than return a boolean success/fail, and bailing at various stages incrementing one of them.

But the main functionality change is checking the return values of WP core functions re https://github.com/wp-cli/media-command/issues/43, and acting accordingly.

`Utils\report_batch_operation_results()` has been cloned and adapted locally to add a `$skips` arg and to report errors as failures in the return string, which is probably good elsewhere but would lead to breaking tests probably and maybe BC concerns (though can we assume its value isn't being parsed in command pipes?). Anyway it might make sense to change the `Utils` version instead.

A default behaviour test `media-regenerate.feature:3` has been added. Also tests for SVG `media-regenerate.feature:847`, PDF with/without thumbnails `media-regenerate.feature:988` etc, audio/video with/without cover art `media-regenerate.feature:1125` etc, and all together `media-regenerate.feature:1222`.

**Edit** should add that test audio and video files have temporarily been put on my server pending upload to wp-cli.org.
