### PR TITLE
Set sizes metadata to empty array if doesn't exist.

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -9,7 +9,7 @@ Feature: Regenerate WordPress attachments
       """
       No images found.
       """
-	And the return code should be 0
+    And the return code should be 0
 
   Scenario: Regenerate all images default behavior
     Given download:
@@ -277,7 +277,7 @@ Feature: Regenerate WordPress attachments
       Warning: Can't find "My imported attachment" (ID {ATTACHMENT_ID}).
       Error: No images regenerated (1 failed).
       """
-	And the return code should be 1
+    And the return code should be 1
 
   Scenario: Only regenerate images which are missing sizes
     Given download:
@@ -856,7 +856,7 @@ Feature: Regenerate WordPress attachments
       """
       Error: Unknown image size "test1".
       """
-	And the return code should be 1
+    And the return code should be 1
 
   Scenario: Regenerating SVGs should be marked as skipped and not produce PHP notices
     Given an svg.svg file:
@@ -1125,10 +1125,10 @@ Feature: Regenerate WordPress attachments
   # Test on PHP 5.6 latest only, and iterate over various WP versions.
   @require-wp-latest @require-php-5.6 @less-than-php-7.0
   Scenario Outline: Regenerating audio with thumbnail
-	# If version is trunk/latest then can get warning about checksums not being available, so STDERR may or may not be empty
-	Given I try `wp core download --version=<version> --force`
-	Then the return code should be 0
-	And I run `wp core update-db`
+    # If version is trunk/latest then can get warning about checksums not being available, so STDERR may or may not be empty
+    Given I try `wp core download --version=<version> --force`
+    Then the return code should be 0
+    And I run `wp core update-db`
     And download:
       | path                                     | url                                                       |
       | {CACHE_DIR}/audio-with-400x300-cover.mp3 | http://wp-cli.org/behat-data/audio-with-400x300-cover.mp3 |
@@ -1254,7 +1254,7 @@ Feature: Regenerate WordPress attachments
 
     # Regenerate with Imagick disabled.
     When I try `WP_CLI_TEST_MEDIA_REGENERATE_IMAGICK=0 wp media regenerate --yes`
-	Then the return code should be 0
+    Then the return code should be 0
     And STDOUT should contain:
       """
       Found 1 image to regenerate.

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -699,11 +699,11 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		// In certain situations, eg if file uploaded when applicable image editor such as Imagick unavailable, the sizes metadata may not exist.
-		if ( ! isset( $metadata['sizes'] ) || ! is_array( $metadata['sizes'] ) ) {
+		if ( ! isset( $metadata['sizes'] ) ) {
 			$metadata['sizes'] = array();
 		}
 
-		if ( $this->image_sizes_differ( $image_sizes, $metadata['sizes'] ) ) {
+		if ( $this->image_sizes_differ( $image_sizes, (array) $metadata['sizes'] ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
Closes #60 

In `needs_regeneration()`:

-  skips if no image editor available for an image (previously only skipped if PDF) and warns (unless it's a PDF).
- sets the sizes metadata for an image to an empty array if it doesn't exist before checking it.

Reproduces the issue by uploading a BMP with Imagick disabled so no sizes metadata generated.

Also adds attachment ID to some warnings for better feedback, separates out warnings from progress log on metadata error, and adjusts tests.
  