### PR TITLE
Refactored aspects of the image collection and determination of sizes

### DIFF
--- a/features/media-image-size.feature
+++ b/features/media-image-size.feature
@@ -1,5 +1,6 @@
 Feature: List image sizes
 
+  @require-wp-4.8
   Scenario: Basic usage
     Given a WP install
 

--- a/features/media-image-size.feature
+++ b/features/media-image-size.feature
@@ -5,14 +5,21 @@ Feature: List image sizes
 
     When I run `wp media image-size`
     Then STDOUT should be a table containing rows:
-      | name       | width     | height    | crop   | ratio |
-      | full       |           |           | N/A    | N/A   |
-      | large      | 1024      | 1024      | soft   | N/A   |
+      | name           | width     | height    | crop   | ratio |
+      | full           |           |           | N/A    | N/A   |
+      | post-thumbnail | 1568      | 9999      | soft   | N/A   |
+      | large          | 1024      | 1024      | soft   | N/A   |
+      | medium_large   | 768       | 0         | soft   | N/A   |
+      | medium         | 300       | 300       | soft   | N/A   |
+      | thumbnail      | 150       | 150       | hard   | 1:1   |
     And STDERR should be empty
 
     When I run `wp media image-size --skip-themes`
     Then STDOUT should be a table containing rows:
-      | name       | width     | height    | crop   | ratio |
-      | full       |           |           | N/A    | N/A   |
-      | large      | 1024      | 1024      | soft   | N/A   |
+      | name           | width     | height    | crop   | ratio |
+      | full           |           |           | N/A    | N/A   |
+      | large          | 1024      | 1024      | soft   | N/A   |
+      | medium_large   | 768       | 0         | soft   | N/A   |
+      | medium         | 300       | 300       | soft   | N/A   |
+      | thumbnail      | 150       | 150       | hard   | 1:1   |
     And STDERR should be empty


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
This PR introduces some refactoring of the `Media_Command.php` file, which in part removes some of the hard-coded arrays that were being used in some of the commands and makes it fully dynamic based on data that is present within WordPress itself (as discussed with @schlessera during WordCamp London 2019 ).

Additionally, there is some prep work being done to advance the further implementation of https://github.com/wp-cli/ideas/issues/32 by moving out the `WP_Query` code into its own function for further reuse.

No tests have been added as nothing has been changed in terms of output. 

