### PR TITLE
Adapt to changes in WP 5.3 image handling to fix broken tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
+        "wp-cli/extension-command": "^2.0",
         "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {

--- a/features/media-fix-orientation.feature
+++ b/features/media-fix-orientation.feature
@@ -11,7 +11,7 @@ Feature: Fix WordPress attachments orientation
       Error: No images found.
       """
 
-  @require-extension-exif @require-wp-4.0
+  @require-extension-exif @require-wp-4.0 @less-than-wp-5.3
   Scenario: Fix orientation for all images
     Given download:
       | path                             | url                                                                            |
@@ -94,7 +94,7 @@ Feature: Fix WordPress attachments orientation
     Success: Images already fixed.
     """
 
-  @require-extension-exif @require-wp-4.0
+  @require-extension-exif @require-wp-4.0 @less-than-wp-5.3
   Scenario: Fix orientation for single image
     When I run `wp media import {CACHE_DIR}/portrait-6.jpg --title="Portrait Six" --porcelain`
     Then save STDOUT as {PORTRAIT_SIX}

--- a/features/media-image-size.feature
+++ b/features/media-image-size.feature
@@ -1,6 +1,6 @@
 Feature: List image sizes
 
-  @require-wp-4.8
+  @require-wp-5.3
   Scenario: Basic usage
     Given a WP install
     # Differing themes can have differing default image sizes. Let's stick to one.
@@ -11,6 +11,36 @@ Feature: List image sizes
       | name           | width     | height    | crop   | ratio |
       | full           |           |           | N/A    | N/A   |
       | 2048x2048      | 2048      | 2048      | soft   | N/A   |
+      | post-thumbnail | 1568      | 9999      | soft   | N/A   |
+      | large          | 1024      | 1024      | soft   | N/A   |
+      | medium_large   | 768       | 0         | soft   | N/A   |
+      | medium         | 300       | 300       | soft   | N/A   |
+      | thumbnail      | 150       | 150       | hard   | 1:1   |
+    And STDERR should be empty
+
+    When I run `wp media image-size --skip-themes`
+    Then STDOUT should be a table containing rows:
+      | name           | width     | height    | crop   | ratio |
+      | full           |           |           | N/A    | N/A   |
+      | large          | 1024      | 1024      | soft   | N/A   |
+      | medium_large   | 768       | 0         | soft   | N/A   |
+      | medium         | 300       | 300       | soft   | N/A   |
+      | thumbnail      | 150       | 150       | hard   | 1:1   |
+    And STDERR should be empty
+
+  # Behavior changed with WordPress 5.3+, so we're adding separate tests for previous versions.
+  # Change that impacts this:
+  # https://core.trac.wordpress.org/ticket/43524
+  @less-than-wp-5.3
+  Scenario: Basic usage (pre-WP-5.3)
+    Given a WP install
+    # Differing themes can have differing default image sizes. Let's stick to one.
+    And I try `wp theme install twentynineteen --activate`
+
+    When I run `wp media image-size`
+    Then STDOUT should be a table containing rows:
+      | name           | width     | height    | crop   | ratio |
+      | full           |           |           | N/A    | N/A   |
       | post-thumbnail | 1568      | 9999      | soft   | N/A   |
       | large          | 1024      | 1024      | soft   | N/A   |
       | medium_large   | 768       | 0         | soft   | N/A   |

--- a/features/media-image-size.feature
+++ b/features/media-image-size.feature
@@ -3,11 +3,14 @@ Feature: List image sizes
   @require-wp-4.8
   Scenario: Basic usage
     Given a WP install
+    # Differing themes can have differing default image sizes. Let's stick to one.
+    And I try `wp theme install twentynineteen --activate`
 
     When I run `wp media image-size`
     Then STDOUT should be a table containing rows:
       | name           | width     | height    | crop   | ratio |
       | full           |           |           | N/A    | N/A   |
+      | 2048x2048      | 2048      | 2048      | soft   | N/A   |
       | post-thumbnail | 1568      | 9999      | soft   | N/A   |
       | large          | 1024      | 1024      | soft   | N/A   |
       | medium_large   | 768       | 0         | soft   | N/A   |

--- a/features/media-image-size.feature
+++ b/features/media-image-size.feature
@@ -31,7 +31,7 @@ Feature: List image sizes
   # Behavior changed with WordPress 5.3+, so we're adding separate tests for previous versions.
   # Change that impacts this:
   # https://core.trac.wordpress.org/ticket/43524
-  @less-than-wp-5.3
+  @require-wp-4.8 @less-than-wp-5.3
   Scenario: Basic usage (pre-WP-5.3)
     Given a WP install
     # Differing themes can have differing default image sizes. Let's stick to one.

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -80,8 +80,12 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
     And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
 
+  # Behavior changed with WordPress 5.3+, so we're adding separate tests for previous versions.
+  # Changes that impact this:
+  # https://core.trac.wordpress.org/ticket/43524
+  # https://core.trac.wordpress.org/ticket/47873
   @less-than-wp-5.3
-  Scenario: Regenerate all images default behavior
+  Scenario: Regenerate all images default behavior (pre-WP-5.3)
     Given download:
       | path                             | url                                               |
       | {CACHE_DIR}/large-image.jpg      | http://wp-cli.org/behat-data/large-image.jpg      |

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -2,6 +2,7 @@ Feature: Regenerate WordPress attachments
 
   Background:
     Given a WP install
+    And I try `wp theme install twentynineteen --activate`
 
   Scenario: Regenerate all images while none exists
     When I try `wp media regenerate --yes`
@@ -21,9 +22,11 @@ Feature: Regenerate WordPress attachments
     When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported large attachment" --porcelain`
     Then save STDOUT as {LARGE_ATTACHMENT_ID}
     And the wp-content/uploads/large-image.jpg file should exist
+    And the wp-content/uploads/large-image-2560.jpg file should exist
     And the wp-content/uploads/large-image-150x150.jpg file should exist
     And the wp-content/uploads/large-image-300x225.jpg file should exist
     And the wp-content/uploads/large-image-1024x768.jpg file should exist
+    And the wp-content/uploads/large-image-2048x1536.jpg file should exist
 
     When I run `wp media import {CACHE_DIR}/canola.jpg --title="My imported medium attachment" --porcelain`
     Then save STDOUT as {MEDIUM_ATTACHMENT_ID}
@@ -50,9 +53,11 @@ Feature: Regenerate WordPress attachments
       Success: Regenerated 2 of 2 images.
       """
     And the wp-content/uploads/large-image.jpg file should exist
+    And the wp-content/uploads/large-image-2560.jpg file should exist
     And the wp-content/uploads/large-image-150x150.jpg file should exist
     And the wp-content/uploads/large-image-300x225.jpg file should exist
     And the wp-content/uploads/large-image-1024x768.jpg file should exist
+    And the wp-content/uploads/large-image-2048x1536.jpg file should exist
     And the wp-content/uploads/canola.jpg file should exist
     And the wp-content/uploads/canola-150x150.jpg file should exist
     And the wp-content/uploads/canola-300x225.jpg file should exist

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -12,11 +12,13 @@ Feature: Regenerate WordPress attachments
       """
     And the return code should be 0
 
+  @require-wp-5.3
   Scenario: Regenerate all images default behavior
     Given download:
       | path                             | url                                               |
       | {CACHE_DIR}/large-image.jpg      | http://wp-cli.org/behat-data/large-image.jpg      |
       | {CACHE_DIR}/canola.jpg           | http://wp-cli.org/behat-data/canola.jpg           |
+      | {CACHE_DIR}/white-150-square.jpg | http://wp-cli.org/behat-data/white-150-square.jpg |
     And I run `wp option update uploads_use_yearmonth_folders 0`
 
     When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported large attachment" --porcelain`
@@ -35,22 +37,33 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/canola-300x225.jpg file should exist
     And the wp-content/uploads/canola-1024x768.jpg file should not exist
 
+    When I run `wp media import {CACHE_DIR}/white-150-square.jpg --title="My imported small attachment" --porcelain`
+    Then save STDOUT as {SMALL_ATTACHMENT_ID}
+    And the wp-content/uploads/white-150-square.jpg file should exist
+    And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
+    And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
+    And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
+
     When I run `wp media regenerate --yes`
     Then STDOUT should contain:
       """
-      Found 2 images to regenerate.
+      Found 3 images to regenerate.
       """
     And STDOUT should contain:
       """
-      /2 Regenerated thumbnails for "My imported large attachment" (ID {LARGE_ATTACHMENT_ID})
+      /3 Regenerated thumbnails for "My imported large attachment" (ID {LARGE_ATTACHMENT_ID})
       """
     And STDOUT should contain:
       """
-      /2 Regenerated thumbnails for "My imported medium attachment" (ID {MEDIUM_ATTACHMENT_ID})
+      /3 Regenerated thumbnails for "My imported medium attachment" (ID {MEDIUM_ATTACHMENT_ID})
       """
     And STDOUT should contain:
       """
-      Success: Regenerated 2 of 2 images.
+      /3 Regenerated thumbnails for "My imported small attachment" (ID {SMALL_ATTACHMENT_ID})
+      """
+    And STDOUT should contain:
+      """
+      Success: Regenerated 3 of 3 images.
       """
     And the wp-content/uploads/large-image.jpg file should exist
     And the wp-content/uploads/large-image-2560.jpg file should exist
@@ -62,15 +75,33 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/canola-150x150.jpg file should exist
     And the wp-content/uploads/canola-300x225.jpg file should exist
     And the wp-content/uploads/canola-1024x768.jpg file should not exist
+    And the wp-content/uploads/white-150-square.jpg file should exist
+    And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
+    And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
+    And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
 
-  # WP < 4.2 produced thumbnails duplicating original, https://core.trac.wordpress.org/ticket/31296
-  # WP 5.3 alpha contains a bug where duplicate resizes are being stored: https://core.trac.wordpress.org/ticket/32437
-  @require-wp-4.2 @less-than-wp-5.3
+  @less-than-wp-5.3
   Scenario: Regenerate all images default behavior
     Given download:
       | path                             | url                                               |
+      | {CACHE_DIR}/large-image.jpg      | http://wp-cli.org/behat-data/large-image.jpg      |
+      | {CACHE_DIR}/canola.jpg           | http://wp-cli.org/behat-data/canola.jpg           |
       | {CACHE_DIR}/white-150-square.jpg | http://wp-cli.org/behat-data/white-150-square.jpg |
     And I run `wp option update uploads_use_yearmonth_folders 0`
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported large attachment" --porcelain`
+    Then save STDOUT as {LARGE_ATTACHMENT_ID}
+    And the wp-content/uploads/large-image.jpg file should exist
+    And the wp-content/uploads/large-image-150x150.jpg file should exist
+    And the wp-content/uploads/large-image-300x225.jpg file should exist
+    And the wp-content/uploads/large-image-1024x768.jpg file should exist
+
+    When I run `wp media import {CACHE_DIR}/canola.jpg --title="My imported medium attachment" --porcelain`
+    Then save STDOUT as {MEDIUM_ATTACHMENT_ID}
+    And the wp-content/uploads/canola.jpg file should exist
+    And the wp-content/uploads/canola-150x150.jpg file should exist
+    And the wp-content/uploads/canola-300x225.jpg file should exist
+    And the wp-content/uploads/canola-1024x768.jpg file should not exist
 
     When I run `wp media import {CACHE_DIR}/white-150-square.jpg --title="My imported small attachment" --porcelain`
     Then save STDOUT as {SMALL_ATTACHMENT_ID}
@@ -82,16 +113,32 @@ Feature: Regenerate WordPress attachments
     When I run `wp media regenerate --yes`
     Then STDOUT should contain:
       """
-      Found 1 image to regenerate.
+      Found 3 images to regenerate.
       """
     And STDOUT should contain:
       """
-      1/1 Regenerated thumbnails for "My imported small attachment" (ID {SMALL_ATTACHMENT_ID})
+      /3 Regenerated thumbnails for "My imported large attachment" (ID {LARGE_ATTACHMENT_ID})
       """
     And STDOUT should contain:
       """
-      Success: Regenerated 1 of 1 images.
+      /3 Regenerated thumbnails for "My imported medium attachment" (ID {MEDIUM_ATTACHMENT_ID})
       """
+    And STDOUT should contain:
+      """
+      /3 Regenerated thumbnails for "My imported small attachment" (ID {SMALL_ATTACHMENT_ID})
+      """
+    And STDOUT should contain:
+      """
+      Success: Regenerated 3 of 3 images.
+      """
+    And the wp-content/uploads/large-image.jpg file should exist
+    And the wp-content/uploads/large-image-150x150.jpg file should exist
+    And the wp-content/uploads/large-image-300x225.jpg file should exist
+    And the wp-content/uploads/large-image-1024x768.jpg file should exist
+    And the wp-content/uploads/canola.jpg file should exist
+    And the wp-content/uploads/canola-150x150.jpg file should exist
+    And the wp-content/uploads/canola-300x225.jpg file should exist
+    And the wp-content/uploads/canola-1024x768.jpg file should not exist
     And the wp-content/uploads/white-150-square.jpg file should exist
     And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
     And the wp-content/uploads/white-150-square-300x300.jpg file should not exist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -565,7 +565,7 @@ class Media_Command extends WP_CLI_Command {
 		}
 		$thumbnail_desc = $image_size ? sprintf( '"%s" thumbnail', $image_size ) : 'thumbnail';
 
-		$fullsizepath = get_attached_file( $id );
+		$fullsizepath = $this->get_attached_file( $id );
 
 		if ( false === $fullsizepath || ! file_exists( $fullsizepath ) ) {
 			WP_CLI::warning( "Can't find $att_desc." );
@@ -1059,7 +1059,7 @@ class Media_Command extends WP_CLI_Command {
 			$att_desc = sprintf( '"%1$s" (ID %2$d)', $title, $id );
 		}
 
-		$full_size_path = get_attached_file( $id );
+		$fullsizepath = $this->get_attached_file( $id );
 
 		if ( false === $full_size_path || ! file_exists( $full_size_path ) ) {
 			WP_CLI::warning( "Can't find {$att_desc}." );
@@ -1183,4 +1183,26 @@ class Media_Command extends WP_CLI_Command {
 		];
 	}
 
+	/**
+	 * Add compatibility indirection to get_attached_file().
+	 *
+	 * In WordPress 5.3, behavior changed to account for automatic resizing of
+	 * big image files.
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/47873
+	 *
+	 * @param int $attachment_id ID of the attachment to get the filepath for.
+	 * @return string|false Filepath of the attachment, or false if not found.
+	 */
+	private function get_attached_file( $attachment_id ) {
+		if ( function_exists( 'wp_get_original_image_path' ) ) {
+			$filepath = wp_get_original_image_path( $attachment_id );
+
+			if ( false !== $filepath ) {
+				return $filepath;
+			}
+		}
+
+		return get_attached_file( $attachment_id );
+	}
 }

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -1059,7 +1059,7 @@ class Media_Command extends WP_CLI_Command {
 			$att_desc = sprintf( '"%1$s" (ID %2$d)', $title, $id );
 		}
 
-		$fullsizepath = $this->get_attached_file( $id );
+		$full_size_path = $this->get_attached_file( $id );
 
 		if ( false === $full_size_path || ! file_exists( $full_size_path ) ) {
 			WP_CLI::warning( "Can't find {$att_desc}." );


### PR DESCRIPTION
* Uses new `wp_get_original_image_path()` function to retrieve filepath to images.
* Skips media reorientation tests on WP 5.3+, as this is done by Core already.
* Adapts to newly added image size 2048x2048