### PR TITLE
Enforce PHP 7.4 compatibility in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.3
+php: 7.4
 
 notifications:
   email:
@@ -51,7 +51,7 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
-      php: 7.4snapshot
+      php: 7.4
       env: WP_VERSION=latest
     - stage: test
       php: 7.3
@@ -78,7 +78,3 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
-  allow_failures:
-    - stage: test
-      php: 7.4snapshot
-      env: WP_VERSION=latest

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -1243,7 +1243,8 @@ Feature: Regenerate WordPress attachments
       | 3.9     |
 
   # Video cover support requires ID3 library 1.9.9, updated WP 4.3 https://core.trac.wordpress.org/ticket/32806
-  @require-wp-4.3
+  # Currently throwing notice on PHP 7.4+: https://core.trac.wordpress.org/ticket/49945
+  @require-wp-4.3 @less-than-php-7.4
   Scenario: Regenerating video with thumbnail
     Given download:
       | path                                        | url                                                          |


### PR DESCRIPTION
This PR changes the Travis CI configuration to use PHP 7.4 for all main tests nd switches the PHP 7.4 tests from allowing failures to failing the build on errors.

It will also include any fixes that might be required to get the tests to pass.

Related: https://core.trac.wordpress.org/ticket/49945