### PR TITLE
Preserve original image metadata, update only relevant size meta.

### DIFF
--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -575,6 +575,8 @@ class Media_Command extends WP_CLI_Command {
 
 		$is_pdf = 'application/pdf' === get_post_mime_type( $id );
 
+		$original_meta = get_post_meta($id, '_wp_attachment_metadata', true);
+
 		$needs_regeneration = $this->needs_regeneration( $id, $fullsizepath, $is_pdf, $image_size, $skip_delete, $skip_it );
 
 		if ( $skip_it ) {
@@ -606,7 +608,7 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		if ( $image_size ) {
-			if ( $this->update_attachment_metadata_for_image_size( $id, $metadata, $image_size ) ) {
+			if ( $this->update_attachment_metadata_for_image_size( $id, $metadata, $image_size, $original_meta ) ) {
 				WP_CLI::log( "$progress Regenerated $thumbnail_desc for $att_desc." );
 			} else {
 				WP_CLI::log( "$progress No $thumbnail_desc regeneration needed for $att_desc." );
@@ -868,8 +870,7 @@ class Media_Command extends WP_CLI_Command {
 	}
 
 	// Update attachment sizes metadata just for a particular intermediate image size.
-	private function update_attachment_metadata_for_image_size( $id, $new_metadata, $image_size ) {
-		$metadata = wp_get_attachment_metadata( $id );
+	private function update_attachment_metadata_for_image_size( $id, $new_metadata, $image_size, $metadata ) {
 
 		if ( ! is_array( $metadata ) ) {
 			return false;


### PR DESCRIPTION
This patch addresses issue #130. When the `--image_size` option is used, it'll preserve original image metadata and update only relevant size information.

I'm sorry, but no tests are provided as I'm not well versed with wp tests. Quite a few people reported the issue, so hopefully, someone will contribute their time to write the tests.