### PR TITLE
Fix typo in command argument description

### DIFF
--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -186,7 +186,7 @@ class Media_Command extends WP_CLI_Command {
 	 * : Attachment title (post title field).
 	 *
 	 * [--caption=<caption>]
-	 * : Caption for attachent (post excerpt field).
+	 * : Caption for attachment (post excerpt field).
 	 *
 	 * [--alt=<alt_text>]
 	 * : Alt text for image (saved as post meta).


### PR DESCRIPTION
Corrects typo of "attachent" to "attachment" in description for `--caption` parameter in function `import()`. 
Closes #156

