### PR TITLE
Fix read error detection in EXIF discovery

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -1561,6 +1561,7 @@ Feature: Regenerate WordPress attachments
     # Make canola.jpg fail.
     Given a wp-content/uploads/canola.jpg file:
       """
+      We need to have some bytes at least to avoid a PHP notice in exif_imagetype().
       """
 
     When I try `WP_CLI_TEST_MEDIA_REGENERATE_PDF=1 wp media regenerate --yes`

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -597,17 +597,17 @@ class Media_Command extends WP_CLI_Command {
 			return;
 		}
 
-		// On read error, we might only get the filesize returned and nothing else.
-		if ( 1 === count( $metadata ) && array_key_exists( 'filesize', $metadata ) ) {
-			WP_CLI::warning( sprintf( 'Read error while retrieving metadata. (ID %d)', $id ) );
+		// Note it's possible for no metadata to be generated for PDFs if restricted to a specific image size.
+		if ( empty( $metadata ) && ! ( $is_pdf && $image_size ) ) {
+			WP_CLI::warning( sprintf( 'No metadata. (ID %d)', $id ) );
 			WP_CLI::log( "$progress Couldn't regenerate thumbnails for $att_desc." );
 			$errors++;
 			return;
 		}
 
-		// Note it's possible for no metadata to be generated for PDFs if restricted to a specific image size.
-		if ( empty( $metadata ) && ! ( $is_pdf && $image_size ) ) {
-			WP_CLI::warning( sprintf( 'No metadata. (ID %d)', $id ) );
+		// On read error, we might only get the filesize returned and nothing else.
+		if ( 1 === count( $metadata ) && array_key_exists( 'filesize', $metadata ) && ! ( $is_pdf && $image_size ) ) {
+			WP_CLI::warning( sprintf( 'Read error while retrieving metadata. (ID %d)', $id ) );
 			WP_CLI::log( "$progress Couldn't regenerate thumbnails for $att_desc." );
 			$errors++;
 			return;

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -597,6 +597,14 @@ class Media_Command extends WP_CLI_Command {
 			return;
 		}
 
+		// On read error, we might only get the filesize returned and nothing else.
+		if ( 1 === count( $metadata ) && array_key_exists( 'filesize', $metadata ) ) {
+			WP_CLI::warning( sprintf( 'Read error while retrieving metadata. (ID %d)', $id ) );
+			WP_CLI::log( "$progress Couldn't regenerate thumbnails for $att_desc." );
+			$errors++;
+			return;
+		}
+
 		// Note it's possible for no metadata to be generated for PDFs if restricted to a specific image size.
 		if ( empty( $metadata ) && ! ( $is_pdf && $image_size ) ) {
 			WP_CLI::warning( sprintf( 'No metadata. (ID %d)', $id ) );


### PR DESCRIPTION
Try to detect a read error while discovering EXIF properties in an image file.

On older PHP versions, the detection just fails returning anything for `$metadata`. However, with newer PHP versions, it returns an array with only a `'filesize'` key.

This PR adapts the logic to account for this and to fix a test failure on bad JPGs that was introduced by that new behavior.
![Testing · wp-cli_automated-tests@9e9164f - Google Chrome 2022-09-02 at 11 29 09 AM](https://user-images.githubusercontent.com/83631/188198117-9a519103-f93d-4cce-ac0b-1b91f463b5e1.jpeg)
