### PR TITLE
Support --post_name=<name> when importing media

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -87,7 +87,7 @@ Feature: Manage WordPress attachments
       | path                        | url                                              |
       | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
 
-    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --caption="My fabulous caption" --porcelain`
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --title="My imported attachment" --caption="My fabulous caption" --post_name="My post name" --porcelain`
     Then save STDOUT as {ATTACHMENT_ID}
 
     When I run `wp post get {ATTACHMENT_ID} --field=title`
@@ -100,6 +100,12 @@ Feature: Manage WordPress attachments
     Then STDOUT should be:
       """
       My fabulous caption
+      """
+
+    When I run `wp post get {ATTACHMENT_ID} --field=post_name`
+    Then STDOUT should be:
+      """
+      my-post-name
       """
 
   Scenario: Import a file as attachment from a local image and leave it in it's current location

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -181,7 +181,7 @@ class Media_Command extends WP_CLI_Command {
 	 *
 	 * [--post_id=<post_id>]
 	 * : ID of the post to attach the imported files to.
-	 * 
+	 *
 	 * [--post_name=<post_name>]
 	 * : Name of the post to attach the imported files to.
 	 *
@@ -245,11 +245,11 @@ class Media_Command extends WP_CLI_Command {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
-				'title'        => '',
-				'caption'      => '',
-				'alt'          => '',
-				'desc'    	   => '',
-				'post_name'    => '',
+				'title'     => '',
+				'caption'   => '',
+				'alt'       => '',
+				'desc'      => '',
+				'post_name' => '',
 			)
 		);
 
@@ -328,7 +328,7 @@ class Media_Command extends WP_CLI_Command {
 				'post_title'   => $assoc_args['title'],
 				'post_excerpt' => $assoc_args['caption'],
 				'post_content' => $assoc_args['desc'],
-				'post_name'    => $assoc_args['post_name']
+				'post_name'    => $assoc_args['post_name'],
 			);
 
 			if ( ! empty( $file_time ) ) {

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -181,6 +181,9 @@ class Media_Command extends WP_CLI_Command {
 	 *
 	 * [--post_id=<post_id>]
 	 * : ID of the post to attach the imported files to.
+	 * 
+	 * [--post_name=<post_name>]
+	 * : Name of the post to attach the imported files to.
 	 *
 	 * [--title=<title>]
 	 * : Attachment title (post title field).
@@ -242,10 +245,11 @@ class Media_Command extends WP_CLI_Command {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
-				'title'   => '',
-				'caption' => '',
-				'alt'     => '',
-				'desc'    => '',
+				'title'        => '',
+				'caption'      => '',
+				'alt'          => '',
+				'desc'    	   => '',
+				'post_name'    => '',
 			)
 		);
 
@@ -324,6 +328,7 @@ class Media_Command extends WP_CLI_Command {
 				'post_title'   => $assoc_args['title'],
 				'post_excerpt' => $assoc_args['caption'],
 				'post_content' => $assoc_args['desc'],
+				'post_name'    => $assoc_args['post_name']
 			);
 
 			if ( ! empty( $file_time ) ) {


### PR DESCRIPTION
Fixes https://github.com/wp-cli/media-command/issues/100

A small PR to pass through the `--post_name` param. It was my "bottle" from the pickup session. I've updated the test suite, so hopefully should be straightforward to test and review. 

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
