### PR TITLE
Fix tests to account for current core behavior

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -40,7 +40,7 @@ Feature: Regenerate WordPress attachments
     When I run `wp media import {CACHE_DIR}/white-150-square.jpg --title="My imported small attachment" --porcelain`
     Then save STDOUT as {SMALL_ATTACHMENT_ID}
     And the wp-content/uploads/white-150-square.jpg file should exist
-    And the wp-content/uploads/white-150-square-150x150.jpg file should exist
+    And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
     And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
     And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
 
@@ -76,7 +76,7 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/canola-300x225.jpg file should exist
     And the wp-content/uploads/canola-1024x768.jpg file should not exist
     And the wp-content/uploads/white-150-square.jpg file should exist
-    And the wp-content/uploads/white-150-square-150x150.jpg file should exist
+    And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
     And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
     And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


In this PR, I propose to fix the failing tests. It looks like the change was introduced in https://github.com/wp-cli/media-command/commit/3b25705b94dd8c798f5bcb58b65d897b857e6fe9 .

I think that at that time, there was a bug in the WP core that resulted in saving 150x150 thumbnails for 150x150 images. We modified tests in the commit shown above to ensure they check the current core behavior, even if it was considered buggy. 

However, I'm unsure about the exact timing of those events, as tests for the older WP version were marked as skipped in Aug 2019 (https://github.com/wp-cli/media-command/pull/112), tests were modified for the newer WP version in 2021 (https://github.com/wp-cli/media-command/commit/3b25705b94dd8c798f5bcb58b65d897b857e6fe9), but the bug in the core was fixed in Sep 2019 (https://core.trac.wordpress.org/ticket/32437)?