### PR TITLE
Avoid deleting meta for other sizes when running `wp media regenerate` with `--image_size`

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -30,6 +30,25 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/large-image-1024x768.jpg file should exist
     And the wp-content/uploads/large-image-2048x1536.jpg file should exist
 
+    When I run `wp option update medium_size_w 256`
+    And I run `wp option update medium_size_h 256`
+    And I run `wp media regenerate {LARGE_ATTACHMENT_ID} --image_size=medium --skip-delete --only-missing`
+    And I run `wp post meta get {LARGE_ATTACHMENT_ID} _wp_attachment_metadata`
+    Then STDOUT should contain:
+    """
+    'medium'
+    """
+    And STDOUT should contain:
+    """
+    'large'
+    """
+    And STDOUT should contain:
+    """
+    'thumbnail'
+    """
+    And I run `wp option update medium_size_w 300`
+    And I run `wp option update medium_size_h 300`
+
     When I run `wp media import {CACHE_DIR}/canola.jpg --title="My imported medium attachment" --porcelain`
     Then save STDOUT as {MEDIUM_ATTACHMENT_ID}
     And the wp-content/uploads/canola.jpg file should exist

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -30,25 +30,6 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/large-image-1024x768.jpg file should exist
     And the wp-content/uploads/large-image-2048x1536.jpg file should exist
 
-    When I run `wp option update medium_size_w 256`
-    And I run `wp option update medium_size_h 256`
-    And I run `wp media regenerate {LARGE_ATTACHMENT_ID} --image_size=medium --skip-delete --only-missing`
-    And I run `wp post meta get {LARGE_ATTACHMENT_ID} _wp_attachment_metadata`
-    Then STDOUT should contain:
-    """
-    'medium'
-    """
-    And STDOUT should contain:
-    """
-    'large'
-    """
-    And STDOUT should contain:
-    """
-    'thumbnail'
-    """
-    And I run `wp option update medium_size_w 300`
-    And I run `wp option update medium_size_h 300`
-
     When I run `wp media import {CACHE_DIR}/canola.jpg --title="My imported medium attachment" --porcelain`
     Then save STDOUT as {MEDIUM_ATTACHMENT_ID}
     And the wp-content/uploads/canola.jpg file should exist
@@ -695,6 +676,17 @@ Feature: Regenerate WordPress attachments
       "file":"canola-400x400.jpg"
       """
 
+    # Check remaining metadata is present
+    When I run `wp post meta get {ATTACHMENT_ID} _wp_attachment_metadata`
+    Then STDOUT should contain:
+      """
+      'medium'
+      """
+    And STDOUT should contain:
+      """
+      'thumbnail'
+      """
+
     # Regenerate "medium" image size removed above - should be regenerated.
     When I run `wp media regenerate --image_size=medium --only-missing --yes`
     Then STDOUT should contain:
@@ -718,6 +710,17 @@ Feature: Regenerate WordPress attachments
       "file":"canola-300x225.jpg"
       """
 
+    # Check remaining metadata is present
+    When I run `wp post meta get {ATTACHMENT_ID} _wp_attachment_metadata`
+    Then STDOUT should contain:
+      """
+      'medium'
+      """
+    And STDOUT should contain:
+      """
+      'thumbnail'
+      """
+
     # Regenerate "medium" image size whether missing or not - should be regenerated.
     When I run `wp media regenerate --image_size=medium --yes`
     Then STDOUT should contain:
@@ -733,6 +736,17 @@ Feature: Regenerate WordPress attachments
       Success: Regenerated 1 of 1 images.
       """
     And the wp-content/uploads/canola-300x225.jpg file should exist
+
+    # Check remaining metadata is present
+    When I run `wp post meta get {ATTACHMENT_ID} _wp_attachment_metadata`
+    Then STDOUT should contain:
+      """
+      'medium'
+      """
+    And STDOUT should contain:
+      """
+      'thumbnail'
+      """
 
     # Change "test1" image size.
     Given a wp-content/mu-plugins/media-settings.php file:

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -59,7 +59,7 @@ Feature: Regenerate WordPress attachments
     When I run `wp media import {CACHE_DIR}/white-150-square.jpg --title="My imported small attachment" --porcelain`
     Then save STDOUT as {SMALL_ATTACHMENT_ID}
     And the wp-content/uploads/white-150-square.jpg file should exist
-    And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
+    And the wp-content/uploads/white-150-square-150x150.jpg file should exist
     And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
     And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
 
@@ -95,7 +95,7 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/canola-300x225.jpg file should exist
     And the wp-content/uploads/canola-1024x768.jpg file should not exist
     And the wp-content/uploads/white-150-square.jpg file should exist
-    And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
+    And the wp-content/uploads/white-150-square-150x150.jpg file should exist
     And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
     And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
 

--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -40,7 +40,7 @@ Feature: Regenerate WordPress attachments
     When I run `wp media import {CACHE_DIR}/white-150-square.jpg --title="My imported small attachment" --porcelain`
     Then save STDOUT as {SMALL_ATTACHMENT_ID}
     And the wp-content/uploads/white-150-square.jpg file should exist
-    And the wp-content/uploads/white-150-square-150x150.jpg file should exist
+    And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
     And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
     And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
 
@@ -76,7 +76,7 @@ Feature: Regenerate WordPress attachments
     And the wp-content/uploads/canola-300x225.jpg file should exist
     And the wp-content/uploads/canola-1024x768.jpg file should not exist
     And the wp-content/uploads/white-150-square.jpg file should exist
-    And the wp-content/uploads/white-150-square-150x150.jpg file should exist
+    And the wp-content/uploads/white-150-square-150x150.jpg file should not exist
     And the wp-content/uploads/white-150-square-300x300.jpg file should not exist
     And the wp-content/uploads/white-150-square-1024x1024.jpg file should not exist
 

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -580,6 +580,8 @@ class Media_Command extends WP_CLI_Command {
 
 		$is_pdf = 'application/pdf' === get_post_mime_type( $id );
 
+		$original_meta = wp_get_attachment_metadata( $id );
+
 		$needs_regeneration = $this->needs_regeneration( $id, $fullsizepath, $is_pdf, $image_size, $skip_delete, $skip_it );
 
 		if ( $skip_it ) {
@@ -619,7 +621,7 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		if ( $image_size ) {
-			if ( $this->update_attachment_metadata_for_image_size( $id, $metadata, $image_size ) ) {
+			if ( $this->update_attachment_metadata_for_image_size( $id, $metadata, $image_size, $original_meta ) ) {
 				WP_CLI::log( "$progress Regenerated $thumbnail_desc for $att_desc." );
 			} else {
 				WP_CLI::log( "$progress No $thumbnail_desc regeneration needed for $att_desc." );
@@ -886,8 +888,7 @@ class Media_Command extends WP_CLI_Command {
 	}
 
 	// Update attachment sizes metadata just for a particular intermediate image size.
-	private function update_attachment_metadata_for_image_size( $id, $new_metadata, $image_size ) {
-		$metadata = wp_get_attachment_metadata( $id );
+	private function update_attachment_metadata_for_image_size( $id, $new_metadata, $image_size, $metadata ) {
 
 		if ( ! is_array( $metadata ) ) {
 			return false;


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

In this PR, I propose to fix the `regenerate` command issue, which causes removing other sizes from post meta when the command is used with the `--image_size` option.

Testing steps:

1. Upload the image
2. Change the size settings for `medium` in WordPress:
3. Regenerate the thumbnails:

```
wp media regenerate --image_size=medium --skip-delete --only-missing
```

4. Check postmeta table for `_wp_attachment_metadata` e.g.:

```
wp post list --post_type=attachment
wp post meta get 5 _wp_attachment_metadata
```

The actual fix and tests come from https://github.com/wp-cli/media-command/pull/141.

Fixes https://github.com/wp-cli/media-command/issues/130