### PR TITLE
Fx typo in import command longdesc

### DIFF
--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -206,7 +206,7 @@ class Media_Command extends WP_CLI_Command {
 	 * Remote files will always use the current time.
 	 *
 	 * [--featured_image]
-	 * : If set, set the imported image as the Featured Image of the post its attached to.
+	 * : If set, set the imported image as the Featured Image of the post it is attached to.
 	 *
 	 * [--porcelain]
 	 * : Output just the new attachment ID.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


**What is the current behavior?** (You can also link to an open issue here)
Typo in longdesc for the `import` command, the optional positional argument `--featured_image`.


**What is the new behavior (if this is a feature change)?**
Fixed typo


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**: