### PR TITLE
Remove `trunk` from this scenario

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -1269,7 +1269,6 @@ Feature: Regenerate WordPress attachments
     Examples:
       | version |
       | latest  |
-      | trunk   |
       | 4.2     |
       | 3.9     |
 


### PR DESCRIPTION
Now that `trunk` no longer supports PHP 5.6 and the version range is `@require-php-5.6 @less-than-php-7.0`, it's no longer necessary to test this scenario against trunk.

See https://github.com/wp-cli/wp-cli/issues/5810