### PR TITLE
Run test only on PHP 7.0+

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -1212,8 +1212,8 @@ Feature: Regenerate WordPress attachments
     And STDERR should be empty
 
   # Audio/video `_cover_hash` meta, used to determine if sub attachment, added in WP 3.9
-  # Test on PHP 5.6 latest only, and iterate over various WP versions.
-  @require-wp-latest @require-php-5.6 @less-than-php-7.0
+  # Test on PHP 7.0 latest only, and iterate over various WP versions.
+  @require-wp-latest @require-php-7.0
   Scenario Outline: Regenerating audio with thumbnail
     # If version is trunk/latest then can get warning about checksums not being available, so STDERR may or may not be empty
     Given I try `wp core download --version=<version> --force`


### PR DESCRIPTION
Tests involving the WP release can now only run on PHP 7.0+ due to the new minimum requirement.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
