### PR TITLE
Added '--porcelain_url' flag to output URL instead of attachment ID

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -215,7 +215,6 @@ Feature: Manage WordPress attachments
       """
     And the return code should be 1
 
-  @justin
   Scenario: Return upload URL after importing a single valid file
     Given download:
       | path                        | url                                              |
@@ -227,7 +226,6 @@ Feature: Manage WordPress attachments
       /large-image.jpg
       """
 
-  @justin
   Scenario: Return upload URL after importing a multiple valid files
     Given download:
       | path                        | url                                              |

--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -214,3 +214,32 @@ Feature: Manage WordPress attachments
       Warning: Unable to import file 'gobbledygook.png'. Reason: File doesn't exist.
       """
     And the return code should be 1
+
+  @justin
+  Scenario: Return upload URL after importing a single valid file
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+
+    When I run `wp media import {CACHE_DIR}/large-image.jpg --porcelain_url`
+    Then STDOUT should contain:
+      """
+      /large-image.jpg
+      """
+
+  @justin
+  Scenario: Return upload URL after importing a multiple valid files
+    Given download:
+      | path                        | url                                              |
+      | {CACHE_DIR}/large-image.jpg | http://wp-cli.org/behat-data/large-image.jpg     |
+
+    When I run `wp media import 'http://wp-cli.org/behat-data/codeispoetry.png' {CACHE_DIR}/large-image.jpg --porcelain_url`
+    Then STDOUT should contain:
+      """
+      /large-image.jpg
+      """
+
+    And STDOUT should contain:
+      """
+      /codeispoetry.png
+      """

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -211,6 +211,9 @@ class Media_Command extends WP_CLI_Command {
 	 * [--porcelain]
 	 * : Output just the new attachment ID.
 	 *
+	 * [--porcelain_url]
+	 * : If set, the URL of the file will be output on a second line of output instead of attachment ID
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Import all jpgs in the current user's "Pictures" directory, not attached to any post.
@@ -414,6 +417,9 @@ class Media_Command extends WP_CLI_Command {
 
 			if ( Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 				WP_CLI::line( $success );
+			} elseif ( Utils\get_flag_value( $assoc_args, 'porcelain_url') ) {
+				$file_location = wp_get_original_image_url( $success );
+				WP_CLI::line( $file_location );
 			} else {
 				WP_CLI::log(
 					sprintf(
@@ -428,7 +434,7 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		// Report the result of the operation
-		if ( ! Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
+		if ( ! Utils\get_flag_value( $assoc_args, 'porcelain' ) && ! Utils\get_flag_value( $assoc_args, 'porcelain_url' ) ) {
 			Utils\report_batch_operation_results( $noun, 'import', count( $args ), $successes, $errors );
 		} elseif ( $errors ) {
 			WP_CLI::halt( 1 );


### PR DESCRIPTION
This addresses https://github.com/wp-cli/media-command/issues/94
Should output ONLY the URL, instead of attachment ID or verbose descriptions.

Is that the best name for the flag? 

Should we also provide an option for showing the URL in the verbose output?