### PR TITLE
Replace usage of `via.placeholder.com`

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -15,10 +15,10 @@ Feature: Manage WordPress attachments
       """
 
   Scenario: Import media from remote URL with query string
-    When I run `wp media import 'https://dummyimage.com/350x150/ffffff/000000?text=Foo'`
+    When I run `wp media import 'https://dummyimage.com/350x150.jpg?text=Foo'`
     Then STDOUT should contain:
       """
-      Imported file 'https://dummyimage.com/350x150/ffffff/000000?text=Foo' as attachment ID
+      Imported file 'https://dummyimage.com/350x150.jpg?text=Foo' as attachment ID
       """
     And STDOUT should contain:
       """

--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -15,10 +15,10 @@ Feature: Manage WordPress attachments
       """
 
   Scenario: Import media from remote URL with query string
-    When I run `wp media import 'http://via.placeholder.com/350x150.jpg?text=Foo'`
+    When I run `wp media import 'https://dummyimage.com/350x150/ffffff/000000?text=Foo'`
     Then STDOUT should contain:
       """
-      Imported file 'http://via.placeholder.com/350x150.jpg?text=Foo' as attachment ID
+      Imported file 'https://dummyimage.com/350x150/ffffff/000000?text=Foo' as attachment ID
       """
     And STDOUT should contain:
       """


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->

Since the beginning of the year, `placeholder.com` now belongs to a warehouse company. `via.placeholder.com` used to work still, but looks like it stopped working now too.

This replaces usage with `dummyimage.com` in order to fix failing tests.