### PR TITLE
Add `--file_name=<name>` argument for `wp media import`

### DIFF
--- a/features/media-import.feature
+++ b/features/media-import.feature
@@ -25,6 +25,17 @@ Feature: Manage WordPress attachments
       Success: Imported 1 of 1 items.
       """
 
+  Scenario: Import media from remote URL and use input file as attachment name
+    When I run `wp media import 'http://wp-cli.org/behat-data/codeispoetry.png' --file_name=abc`
+    Then STDOUT should contain:
+      """
+      file name abc.png
+      """
+    And STDOUT should contain:
+      """
+      Success: Imported 1 of 1 items.
+      """
+
   Scenario: Fail to import missing image
     When I try `wp media import gobbledygook.png`
     Then STDERR should be:

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -185,6 +185,9 @@ class Media_Command extends WP_CLI_Command {
 	 * [--post_name=<post_name>]
 	 * : Name of the post to attach the imported files to.
 	 *
+	 * [--slug=<slug>]
+	 * : Attachment slug (post_name field).
+	 *
 	 * [--title=<title>]
 	 * : Attachment title (post title field).
 	 *
@@ -249,6 +252,7 @@ class Media_Command extends WP_CLI_Command {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
+				'slug'      => '',
 				'title'     => '',
 				'caption'   => '',
 				'alt'       => '',
@@ -326,6 +330,11 @@ class Media_Command extends WP_CLI_Command {
 					continue;
 				}
 				$name = strtok( Utils\basename( $file ), '?' );
+			}
+
+			if ( ! empty( $assoc_args['slug'] ) ) {
+				$image_slug = $this->get_image_slug( $name, $assoc_args['slug'] );
+				$name       = ! empty( $image_slug ) ? $image_slug : $name;
 			}
 
 			$file_array = array(
@@ -1258,5 +1267,21 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		return wp_get_attachment_url( $attachment_id );
+	}
+
+	/**
+	 * Create image slug based on user input slug.
+	 * Add basename extension to slug.
+	 *
+	 * @param string $basename Default slu of image.
+	 * @param string $slug User input slug.
+	 *
+	 * @return string Image slug with extension.
+	 */
+	private function get_image_slug( $basename, $slug ) {
+
+		$extension = pathinfo( $basename, PATHINFO_EXTENSION );
+
+		return $slug . '.' . $extension;
 	}
 }

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -423,6 +423,10 @@ class Media_Command extends WP_CLI_Command {
 			}
 
 			$attachment_success_text = '';
+			if ( $assoc_args['file_name'] ) {
+				$attachment_success_text .= ", file name {$name}";
+			}
+
 			if ( $assoc_args['post_id'] ) {
 				$attachment_success_text = " and attached to post {$assoc_args['post_id']}";
 				if ( Utils\get_flag_value( $assoc_args, 'featured_image' ) ) {

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -424,7 +424,7 @@ class Media_Command extends WP_CLI_Command {
 
 			$attachment_success_text = '';
 			if ( $assoc_args['file_name'] ) {
-				$attachment_success_text .= ", file name {$name}";
+				$attachment_success_text .= " with file name {$name}";
 			}
 
 			if ( $assoc_args['post_id'] ) {

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -185,8 +185,8 @@ class Media_Command extends WP_CLI_Command {
 	 * [--post_name=<post_name>]
 	 * : Name of the post to attach the imported files to.
 	 *
-	 * [--slug=<slug>]
-	 * : Attachment slug (post_name field).
+	 * [--file_name=<name>]
+	 * : Attachment name (post_name field).
 	 *
 	 * [--title=<title>]
 	 * : Attachment title (post title field).
@@ -252,7 +252,7 @@ class Media_Command extends WP_CLI_Command {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
-				'slug'      => '',
+				'file_name' => '',
 				'title'     => '',
 				'caption'   => '',
 				'alt'       => '',
@@ -332,9 +332,9 @@ class Media_Command extends WP_CLI_Command {
 				$name = strtok( Utils\basename( $file ), '?' );
 			}
 
-			if ( ! empty( $assoc_args['slug'] ) ) {
-				$image_slug = $this->get_image_slug( $name, $assoc_args['slug'] );
-				$name       = ! empty( $image_slug ) ? $image_slug : $name;
+			if ( ! empty( $assoc_args['file_name'] ) ) {
+				$image_name = $this->get_image_name( $name, $assoc_args['file_name'] );
+				$name       = ! empty( $image_name ) ? $image_name : $name;
 			}
 
 			$file_array = array(
@@ -1278,7 +1278,7 @@ class Media_Command extends WP_CLI_Command {
 	 *
 	 * @return string Image slug with extension.
 	 */
-	private function get_image_slug( $basename, $slug ) {
+	private function get_image_name( $basename, $slug ) {
 
 		$extension = pathinfo( $basename, PATHINFO_EXTENSION );
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
Added a slug option for media

Issue - https://github.com/wp-cli/media-command/issues/186
