### PR TITLE
Remove extraneous error check

### DIFF
--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -630,12 +630,6 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		$metadata = wp_generate_attachment_metadata( $id, $fullsizepath );
-		if ( is_wp_error( $metadata ) ) {
-			WP_CLI::warning( sprintf( '%s (ID %d)', $metadata->get_error_message(), $id ) );
-			WP_CLI::log( "$progress Couldn't regenerate thumbnails for $att_desc." );
-			++$errors;
-			return;
-		}
 
 		// Note it's possible for no metadata to be generated for PDFs if restricted to a specific image size.
 		if ( empty( $metadata ) && ! ( $is_pdf && $image_size ) ) {


### PR DESCRIPTION
Fixes https://github.com/wp-cli/media-command/issues/190

I think we don't need to add another test for this PR. After adding separate test for this change I realized there is already similar test for the case when media could not be regenerated. So I reverted the tests addition. See: https://github.com/wp-cli/media-command/blob/main/features/media-regenerate.feature#L309 