### PR TITLE
Add reason for skipping regeneration in wp media regenerate

### DIFF
--- a/features/media-regenerate.feature
+++ b/features/media-regenerate.feature
@@ -1146,7 +1146,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      1/1 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {ATTACHMENT_ID})
+      1/1 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {ATTACHMENT_ID}): no editor available for image/svg+xml.
       """
     And STDOUT should not contain:
       """
@@ -1166,7 +1166,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      1/1 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {ATTACHMENT_ID})
+      1/1 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {ATTACHMENT_ID}): no editor available for image/svg+xml.
       """
     And STDOUT should not contain:
       """
@@ -1213,7 +1213,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /2 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID})
+      /2 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID}): no editor available for application/pdf.
       """
     And STDOUT should contain:
       """
@@ -1237,7 +1237,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /2 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID})
+      /2 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID}): no editor available for application/pdf.
       """
     And STDOUT should contain:
       """
@@ -1286,7 +1286,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /1 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID})
+      /1 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID}): no editor available for application/pdf.
       """
     And STDOUT should not contain:
       """
@@ -1371,7 +1371,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /1 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID})
+      /1 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID}): no editor available for application/pdf.
       """
     And STDOUT should not contain:
       """
@@ -1470,7 +1470,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      1/1 Skipped thumbnail regeneration for "My imported BMP attachment" (ID {BMP_ATTACHMENT_ID}).
+      1/1 Skipped thumbnail regeneration for "My imported BMP attachment" (ID {BMP_ATTACHMENT_ID}): no editor available for image/bmp.
       """
     And STDOUT should contain:
       """
@@ -1529,7 +1529,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      1/1 Skipped thumbnail regeneration for "My imported BMP attachment" (ID {BMP_ATTACHMENT_ID}).
+      1/1 Skipped thumbnail regeneration for "My imported BMP attachment" (ID {BMP_ATTACHMENT_ID}): no editor available for image/bmp.
       """
     And STDOUT should contain:
       """
@@ -1621,7 +1621,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}).
+      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}): no editor available for image/svg+xml.
       """
     And STDOUT should contain:
       """
@@ -1653,11 +1653,11 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}).
+      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}): no editor available for image/svg+xml.
       """
     And STDOUT should contain:
       """
-      /4 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID}).
+      /4 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID}): no editor available for application/pdf.
       """
     And STDOUT should contain:
       """
@@ -1683,11 +1683,11 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}).
+      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}): no editor available for image/svg+xml.
       """
     And STDOUT should contain:
       """
-      /4 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID}).
+      /4 Skipped thumbnail regeneration for "My imported PDF attachment" (ID {PDF_ATTACHMENT_ID}): no editor available for application/pdf.
       """
     And STDOUT should contain:
       """
@@ -1716,7 +1716,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}).
+      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}): no editor available for image/svg+xml.
       """
     And STDOUT should contain:
       """
@@ -1765,7 +1765,7 @@ Feature: Regenerate WordPress attachments
       """
     And STDOUT should contain:
       """
-      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}).
+      /4 Skipped thumbnail regeneration for "My imported SVG attachment" (ID {SVG_ATTACHMENT_ID}): no editor available for image/svg+xml.
       """
     And STDOUT should contain:
       """

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -1167,7 +1167,7 @@ class Media_Command extends WP_CLI_Command {
 		$needs_regeneration = $this->needs_regeneration( $id, $fullsizepath, $is_pdf, $image_sizes, $skip_delete, $skip_it );
 
 		if ( $skip_it ) {
-			WP_CLI::log( "$progress Skipped $thumbnail_desc regeneration for $att_desc." );
+			WP_CLI::log( "$progress Skipped $thumbnail_desc regeneration for $att_desc: $skip_it." );
 			++$skips;
 			return;
 		}
@@ -1429,8 +1429,8 @@ class Media_Command extends WP_CLI_Command {
 	 * @param bool $is_pdf
 	 * @param string[] $image_sizes
 	 * @param bool $skip_delete
-	 * @param bool $skip_it
-	 * @param-out bool $skip_it
+	 * @param string|false $skip_it Reason string if skipping, false otherwise.
+	 * @param-out string|false $skip_it
 	 * @return bool
 	 */
 	private function needs_regeneration( $att_id, $fullsizepath, $is_pdf, $image_sizes, $skip_delete, &$skip_it ) {
@@ -1449,7 +1449,9 @@ class Media_Command extends WP_CLI_Command {
 			if ( ! $is_pdf && is_array( $metadata ) && ! empty( $metadata['sizes'] ) ) {
 				WP_CLI::warning( sprintf( '%s (ID %d)', $attachment_sizes->get_error_message(), $att_id ) );
 			}
-			$skip_it = true;
+			$mime_type = get_post_mime_type( $att_id );
+			$skip_it   = sprintf( 'no editor available for %s', $mime_type ? $mime_type : 'this file type' );
+			WP_CLI::debug( sprintf( 'Skipping attachment %d: %s.', $att_id, $skip_it ), 'media' );
 			return false;
 		}
 
@@ -1481,6 +1483,7 @@ class Media_Command extends WP_CLI_Command {
 			$filtered_sizes = array_intersect_key( $attachment_sizes, array_flip( $image_sizes ) );
 
 			if ( empty( $filtered_sizes ) ) {
+				WP_CLI::debug( sprintf( 'Skipping attachment %d: no requested sizes apply to this attachment.', $att_id ), 'media' );
 				return false;
 			}
 
@@ -1501,6 +1504,7 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		if ( $this->image_sizes_differ( $attachment_sizes, $metadata['sizes'] ) ) {
+			WP_CLI::debug( sprintf( 'Regenerating attachment %d: image sizes have changed.', $att_id ), 'media' );
 			return true;
 		}
 
@@ -1519,9 +1523,12 @@ class Media_Command extends WP_CLI_Command {
 			}
 
 			if ( ! file_exists( $intermediate_path ) ) {
+				WP_CLI::debug( sprintf( 'Regenerating attachment %d: missing thumbnail file "%s".', $att_id, $size_info['file'] ), 'media' );
 				return true;
 			}
 		}
+
+		WP_CLI::debug( sprintf( 'Attachment %d: all thumbnails up to date.', $att_id ), 'media' );
 		return false;
 	}
 

--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -1167,7 +1167,7 @@ class Media_Command extends WP_CLI_Command {
 		$needs_regeneration = $this->needs_regeneration( $id, $fullsizepath, $is_pdf, $image_sizes, $skip_delete, $skip_it );
 
 		if ( $skip_it ) {
-			WP_CLI::log( "$progress Skipped $thumbnail_desc regeneration for $att_desc: $skip_it." );
+			WP_CLI::log( "$progress Skipped $thumbnail_desc regeneration for $att_desc: $skip_it" );
 			++$skips;
 			return;
 		}
@@ -1450,7 +1450,7 @@ class Media_Command extends WP_CLI_Command {
 				WP_CLI::warning( sprintf( '%s (ID %d)', $attachment_sizes->get_error_message(), $att_id ) );
 			}
 			$mime_type = get_post_mime_type( $att_id );
-			$skip_it   = sprintf( 'no editor available for %s', $mime_type ? $mime_type : 'this file type' );
+			$skip_it   = sprintf( 'no editor available for %s.', $mime_type ? $mime_type : 'this file type' );
 			WP_CLI::debug( sprintf( 'Skipping attachment %d: %s.', $att_id, $skip_it ), 'media' );
 			return false;
 		}
@@ -1483,7 +1483,7 @@ class Media_Command extends WP_CLI_Command {
 			$filtered_sizes = array_intersect_key( $attachment_sizes, array_flip( $image_sizes ) );
 
 			if ( empty( $filtered_sizes ) ) {
-				WP_CLI::debug( sprintf( 'Skipping attachment %d: no requested sizes apply to this attachment.', $att_id ), 'media' );
+				WP_CLI::debug( sprintf( 'Not regenerating attachment %d: no requested sizes apply to this attachment.', $att_id ), 'media' );
 				return false;
 			}
 


### PR DESCRIPTION
## Summary

Fixes #95

When `wp media regenerate` skips a thumbnail, the output message now includes the **specific reason** for the skip. This helps users understand immediately why regeneration was skipped without needing to investigate further.

Additionally, `WP_CLI::debug()` output has been added throughout the regeneration decision logic, providing detailed diagnostics when `--debug` is used.

### Changes

- **Skip reason in output**: The skip message now includes the reason string (e.g., `no editor available for image/svg+xml`)
- **Debug output**: Added `WP_CLI::debug()` calls for all decision paths in `needs_regeneration()`:
  - No editor available for file type
  - No requested sizes apply to the attachment
  - Image sizes have changed (needs regeneration)
  - Missing thumbnail file (needs regeneration)
  - All thumbnails up to date
- **Updated tests**: All 15 test assertions updated to match the new message format

### Before

```
1/1 Skipped thumbnail regeneration for "logo.svg" (ID 42).
```

### After

```
1/1 Skipped thumbnail regeneration for "logo.svg" (ID 42): no editor available for image/svg+xml.
```

With `--debug`:
```
Debug (media): Skipping attachment 42: no editor available for image/svg+xml.
```

## Test plan

- [ ] Run `wp media regenerate --yes` on a site with SVG/PDF/BMP attachments and verify skip messages include the reason
- [ ] Run `wp media regenerate --yes --debug` and verify debug output shows decision details for each attachment
- [ ] Run existing Behat test suite: `vendor/bin/behat features/media-regenerate.feature`
- [ ] Verify no regressions for normal image regeneration (JPG/PNG)

---

*Submitted during WCAsia 2026 Contributor Day — tracked in wp-cli/wp-cli#6295*