### PR TITLE
Exclude the wp-compat false positives from the PHPStan config

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,3 +10,30 @@ parameters:
   treatPhpDocTypesAsCertain: false
   ignoreErrors:
     - identifier: missingType.iterableValue
+
+    # johnbillion/wp-compat checks every WordPress symbol against the WordPress 4.9
+    # baseline that wp-cli-tests configures. It only recognizes function_exists() and
+    # method_exists() guards, so it cannot see the `wp_version_compare()` checks used
+    # throughout this command.
+
+    # WordPress 6.0 only formalized the already documented `...$args` parameter of
+    # `apply_filters()` by adding it to the function signature. Additional arguments
+    # were collected through `func_get_args()` before that. The two
+    # `intermediate_image_sizes_advanced` calls are already split across a
+    # `wp_version_compare()` check for exactly this reason.
+    -
+      identifier: WPCompat.parameterNotAvailable.applyfilters.args
+      path: src/Media_Command.php
+
+    # The WordPress 6.0 change to `wp_generate_attachment_metadata()` added the
+    # `$filesize` value to the *returned array*. The `$file` parameter itself has been
+    # there since WordPress 2.1.
+    -
+      identifier: WPCompat.parameterNotAvailable.wpgenerateattachmentmetadata.file
+      path: src/Media_Command.php
+
+    # `Media_Command::wp_get_registered_image_subsizes()` only calls its WordPress 5.3
+    # namesake behind a `wp_version_compare()` check, and reimplements it otherwise.
+    -
+      identifier: WPCompat.functionNotAvailable
+      path: src/Media_Command.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -36,4 +36,5 @@ parameters:
     # namesake behind a `wp_version_compare()` check, and reimplements it otherwise.
     -
       identifier: WPCompat.functionNotAvailable
+      message: '#^wp_get_registered_image_subsizes\(\) is only available since WordPress version 5\.3\.0\.$#'
       path: src/Media_Command.php


### PR DESCRIPTION
The `johnbillion/wp-compat` PHPStan extension that now ships with `wp-cli-tests` checks every WordPress symbol against the WordPress 4.9 baseline that `wp-cli-tests` configures, and only recognizes `function_exists()` and `method_exists()` guards — not `wp_version_compare()`, which is what this command uses throughout.

All eight errors it reported are false positives.

| Count | Reported | Why it is a false positive |
| --- | --- | --- |
| 4 | `Parameter $file of wp_generate_attachment_metadata() is only available since WordPress version 6.0.0` | The WordPress 6.0 change was `The $filesize value was added to the returned array` — it did not touch the `$file` parameter, which has been there since WordPress 2.1. The extension appears to be attributing a `@since` note about the return value to the parameter |
| 3 | `Parameter $args of apply_filters() is only available since WordPress version 6.0.0` | WordPress 6.0 only "formalized the existing and already documented `...$args` parameter by adding it to the function signature"; extra arguments were collected through `func_get_args()` before that. Worth noting the two `intermediate_image_sizes_advanced` calls at lines 1750 and 1753 are *already* split across a `wp_version_compare( '5.3', '>=' )` check for exactly this reason, and both branches get flagged regardless |
| 1 | `wp_get_registered_image_subsizes() is only available since WordPress version 5.3.0` | `Media_Command::wp_get_registered_image_subsizes()` calls its WordPress 5.3 namesake only inside a `wp_version_compare( '5.3', '>=' )` branch, and reimplements the behaviour from `$_wp_additional_image_sizes` otherwise |

Ignored in `phpstan.neon.dist` with the reason documented for each group. The two parameter entries use identifiers that already pin one parameter of one function. The function-availability entry additionally matches on the message, per review on this PR, so it covers only `wp_get_registered_image_subsizes()` rather than every `WPCompat.functionNotAvailable` diagnostic in a 2300 line file — a call to anything newer than the WordPress 4.9 baseline still surfaces.

No source changes: none of these is an actual compatibility problem.

## Verification

Run locally against the same dependency versions CI resolves (`johnbillion/wp-compat` 2.0.0, `php-stubs/wordpress-stubs` v6.9.4, `wp-cli/wp-cli-tests` v5.2.3):

- `composer phpstan` — `[OK] No errors`
- As a control, adding a deliberately dead ignore entry does produce an `ignore.unmatched` error, confirming the three entries above match real errors rather than sitting there unused

GitHub Actions was failing to allocate runners across the org while this was written, so CI may need a re-run once that clears.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks for supported WordPress versions.
  * Prevented false-positive static analysis warnings related to media processing and WordPress compatibility.
