### PR TITLE
Fix PHPStan errors with WordPress 7.1 stubs

### DIFF
--- a/src/Media_Command.php
+++ b/src/Media_Command.php
@@ -198,9 +198,10 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		$images = $this->get_images( $args, $additional_mime_types );
+		$posts  = $images->posts;
 		$count  = $images->post_count;
 
-		if ( ! $count ) {
+		if ( ! $count || ! is_array( $posts ) ) {
 			WP_CLI::warning( 'No images found.' );
 			return;
 		}
@@ -225,7 +226,7 @@ class Media_Command extends WP_CLI_Command {
 		/**
 		 * @var int $post_id
 		 */
-		foreach ( $images->posts as $post_id ) {
+		foreach ( $posts as $post_id ) {
 			++$number;
 			if ( 0 === $number % self::WP_CLEAR_OBJECT_CACHE_INTERVAL ) {
 				// @phpstan-ignore function.deprecated
@@ -338,9 +339,10 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		$images = $this->get_images( $args, $additional_mime_types );
+		$posts  = $images->posts;
 		$count  = $images->post_count;
 
-		if ( ! $count ) {
+		if ( ! $count || ! is_array( $posts ) ) {
 			WP_CLI::warning( 'No images found.' );
 			return;
 		}
@@ -361,7 +363,7 @@ class Media_Command extends WP_CLI_Command {
 		/**
 		 * @var int $post_id
 		 */
-		foreach ( $images->posts as $post_id ) {
+		foreach ( $posts as $post_id ) {
 			++$number;
 			if ( 0 === $number % self::WP_CLEAR_OBJECT_CACHE_INTERVAL ) {
 				// @phpstan-ignore function.deprecated
@@ -1861,7 +1863,7 @@ class Media_Command extends WP_CLI_Command {
 	 * @param int $id
 	 * @param array $new_metadata
 	 * @param string[] $image_sizes
-	 * @param array{sizes: array<string, mixed>}|false $metadata
+	 * @param array{sizes?: array<string, mixed>}|false $metadata
 	 * @return string[] The sizes that were actually regenerated.
 	 */
 	private function update_attachment_metadata_for_image_size( $id, $new_metadata, $image_sizes, $metadata ) {
@@ -2054,10 +2056,11 @@ class Media_Command extends WP_CLI_Command {
 		}
 
 		$images  = $this->get_images( $args );
+		$posts   = $images->posts;
 		$count   = $images->post_count;
 		$dry_run = Utils\get_flag_value( $assoc_args, 'dry-run' );
 
-		if ( ! $count ) {
+		if ( ! $count || ! is_array( $posts ) ) {
 			WP_CLI::error( 'No images found.' );
 		}
 
@@ -2068,7 +2071,7 @@ class Media_Command extends WP_CLI_Command {
 		/**
 		 * @var int $post_id
 		 */
-		foreach ( $images->posts as $post_id ) {
+		foreach ( $posts as $post_id ) {
 			++$number;
 			if ( 0 === $number % self::WP_CLEAR_OBJECT_CACHE_INTERVAL ) {
 				// @phpstan-ignore function.deprecated


### PR DESCRIPTION
`php-stubs/wordpress-stubs` v7.1.0 tightened a couple of WP core types, which surfaced four new PHPStan errors:

- `WP_Query::$posts` is now `WP_Post[]|int[]|null`. The three `foreach ( $images->posts ... )` loops now read the property into a local and include it in the existing "No images found." guard.
- `wp_get_attachment_metadata()` now returns a precise array shape in which `sizes` is optional, so the `@param` of `Media_Command::update_attachment_metadata_for_image_size()` was corrected to `array{sizes?: array<string, mixed>}|false`.

No runtime behaviour change. `composer phpstan` and `phpcs` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PGksEeKBJuBAjUKEV3B9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no image results are returned, preventing processing errors.
  * Updated image regeneration, pruning, and orientation correction to process results more reliably.

* **Documentation**
  * Clarified that image size metadata is optional when updating attachment metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->