### PR TITLE
Remove obsolete wp_generate_attachment_metadata() PHPStan ignore entry

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,13 +25,6 @@ parameters:
       identifier: WPCompat.parameterNotAvailable.applyfilters.args
       path: src/Media_Command.php
 
-    # The WordPress 6.0 change to `wp_generate_attachment_metadata()` added the
-    # `$filesize` value to the *returned array*. The `$file` parameter itself has been
-    # there since WordPress 2.1.
-    -
-      identifier: WPCompat.parameterNotAvailable.wpgenerateattachmentmetadata.file
-      path: src/Media_Command.php
-
     # `Media_Command::wp_get_registered_image_subsizes()` only calls its WordPress 5.3
     # namesake behind a `wp_version_compare()` check, and reimplements it otherwise.
     -


### PR DESCRIPTION
`johnbillion/wp-compat` 2.0.1 stopped reporting the `$file` parameter of `wp_generate_attachment_metadata()` as version-gated, fixing the false positive that the `WPCompat.parameterNotAvailable.wpgenerateattachmentmetadata.file` entry existed to suppress.

With nothing left to match, PHPStan now fails with a non-ignorable `Ignored error pattern ... was not matched in reported errors`, which is what broke the scheduled Code Quality run on `main` ([run 33288245696](https://github.com/wp-cli/media-command/actions/runs/33288245696)). Removing the entry restores a clean analysis.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PGksEeKBJuBAjUKEV3B9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis configuration by removing an outdated compatibility exception.
  * All other analysis rules remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->